### PR TITLE
Improve HtBody performance

### DIFF
--- a/src/main/java/org/cactoos/http/io/SkipInput.java
+++ b/src/main/java/org/cactoos/http/io/SkipInput.java
@@ -1,0 +1,150 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.cactoos.http.io;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Iterator;
+import org.cactoos.Bytes;
+import org.cactoos.Input;
+
+/**
+ * {@link Input} that skips until it find some defined bytes.
+ *
+ * @author Victor Noel (victor.noel@crazydwarves.org)
+ * @version $Id$
+ * @since 0.1
+ */
+public final class SkipInput implements Input {
+
+    /**
+     * The input.
+     */
+    private final Input origin;
+
+    /**
+     * The delimiter.
+     */
+    private final Bytes delimiter;
+
+    /**
+     * Ctor.
+     *
+     * @param origin The input.
+     * @param delimiter The bytes delimiter to skip until.
+     */
+    public SkipInput(final Input origin, final Bytes delimiter) {
+        this.origin = origin;
+        this.delimiter = delimiter;
+    }
+
+    @Override
+    public InputStream stream() throws IOException {
+        final byte[] bytes = this.delimiter.asBytes();
+        final BoundedByteBuffer buffer = new BoundedByteBuffer(
+            bytes.length
+        );
+        final InputStream stream = this.origin.stream();
+        boolean eof = false;
+        while (!eof && !buffer.isEqualsTo(bytes)) {
+            final int read = stream.read();
+            if (read < 0) {
+                eof = true;
+            } else {
+                buffer.offer((byte) read);
+            }
+        }
+        return stream;
+    }
+
+    /**
+     * A very simple circular buffer of bytes.
+     *
+     * @author Victor Noel (victor.noel@crazydwarves.org)
+     * @version $Id$
+     * @since 0.1
+     * @todo #3:30min this internal class should be transformed to a full
+     *  fledged public class with a clear interface, either in the cactoos or
+     *  the cactoos-http project and the implementation is not efficient in
+     *  memory usage because of the boxing of bytes into an object. This should
+     *  be replaced by a real circular byte buffer implementation with
+     *  primitive bytes.
+     */
+    static final class BoundedByteBuffer {
+
+        /**
+         * The buffer.
+         */
+        private final Deque<Byte> internal;
+
+        /**
+         * The size limit.
+         */
+        private final int limit;
+
+        /**
+         * Ctor.
+         *
+         * @param limit The size limit.
+         */
+        BoundedByteBuffer(final int limit) {
+            this.limit = limit;
+            this.internal = new ArrayDeque<>(limit);
+        }
+
+        /**
+         * Add a byte to the buffer, potentially by removing the oldest one to
+         * satisfy the size limit.
+         *
+         * @param add The byte to add
+         */
+        public void offer(final byte add) {
+            if (this.internal.size() == this.limit) {
+                this.internal.removeFirst();
+            }
+            this.internal.addLast(add);
+        }
+
+        /**
+         * Test if the buffer contains exactly the {@code bytes}.
+         *
+         * @param bytes The bytes to compare to.
+         * @return The value {@code true} if the buffer contains exactly
+         *  the {@code bytes}.
+         */
+        public boolean isEqualsTo(final byte[] bytes) {
+            boolean equal = bytes.length == this.internal.size();
+            final Iterator<Byte> iter = this.internal.iterator();
+            int idx = 0;
+            while (iter.hasNext() && equal) {
+                equal = iter.next() == bytes[idx];
+                idx = idx + 1;
+            }
+            return equal;
+        }
+    }
+}

--- a/src/main/java/org/cactoos/http/io/package-info.java
+++ b/src/main/java/org/cactoos/http/io/package-info.java
@@ -22,39 +22,11 @@
  * SOFTWARE.
  */
 
-package org.cactoos.http;
-
-import java.io.IOException;
-import java.io.InputStream;
-import org.cactoos.Input;
-import org.cactoos.http.io.SkipInput;
-import org.cactoos.io.BytesOf;
-
 /**
- * Head of HTTP response.
+ * Io for Http.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
  * @author Victor Noel (victor.noel@crazydwarves.org)
  * @version $Id$
  * @since 0.1
  */
-public final class HtBody implements Input {
-
-    /**
-     * Response.
-     */
-    private final Input response;
-
-    /**
-     * Ctor.
-     * @param rsp Response
-     */
-    public HtBody(final Input rsp) {
-        this.response = rsp;
-    }
-
-    @Override
-    public InputStream stream() throws IOException {
-        return new SkipInput(this.response, new BytesOf("\r\n\r\n")).stream();
-    }
-}
+package org.cactoos.http.io;

--- a/src/test/java/org/cactoos/http/io/SkipInputBoundedByteBufferTest.java
+++ b/src/test/java/org/cactoos/http/io/SkipInputBoundedByteBufferTest.java
@@ -22,39 +22,34 @@
  * SOFTWARE.
  */
 
-package org.cactoos.http;
+package org.cactoos.http.io;
 
-import java.io.IOException;
-import java.io.InputStream;
-import org.cactoos.Input;
-import org.cactoos.http.io.SkipInput;
-import org.cactoos.io.BytesOf;
+import java.util.Arrays;
+import org.cactoos.http.io.SkipInput.BoundedByteBuffer;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
 
 /**
- * Head of HTTP response.
+ * Test case for {@link SkipInput.BoundedByteBuffer}.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
  * @author Victor Noel (victor.noel@crazydwarves.org)
  * @version $Id$
  * @since 0.1
+ * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class HtBody implements Input {
+public final class SkipInputBoundedByteBufferTest {
 
-    /**
-     * Response.
-     */
-    private final Input response;
-
-    /**
-     * Ctor.
-     * @param rsp Response
-     */
-    public HtBody(final Input rsp) {
-        this.response = rsp;
-    }
-
-    @Override
-    public InputStream stream() throws IOException {
-        return new SkipInput(this.response, new BytesOf("\r\n\r\n")).stream();
+    @Test
+    public void onlyKeepsTheLastNBytes() {
+        final int limit = 4;
+        final BoundedByteBuffer buffer = new BoundedByteBuffer(limit);
+        final int[] bytes = new int[] {1, 2, 3, 4, 5, 6, 7, 8 };
+        Arrays.stream(bytes).forEach(b -> buffer.offer((byte) b));
+        MatcherAssert.assertThat(
+            // @checkstyle MagicNumberCheck (1 line)
+            buffer.isEqualsTo(new byte[] {5, 6, 7, 8 }),
+            Matchers.is(true)
+        );
     }
 }

--- a/src/test/java/org/cactoos/http/io/SkipInputTest.java
+++ b/src/test/java/org/cactoos/http/io/SkipInputTest.java
@@ -1,0 +1,99 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.cactoos.http.io;
+
+import org.cactoos.io.BytesOf;
+import org.cactoos.io.InputOf;
+import org.cactoos.text.JoinedText;
+import org.cactoos.text.TextOf;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+/**
+ * Test case for {@link SkipInput}.
+ *
+ * @author Victor Noel (victor.noel@crazydwarves.org)
+ * @version $Id$
+ * @since 0.1
+ * @checkstyle JavadocMethodCheck (500 lines)
+ */
+public final class SkipInputTest {
+
+    @Test
+    public void skipsSomeBytes() throws Exception {
+        final String prefix = "Hello dude!";
+        final String suffix = "How are you?";
+        final String delimiter = "\r";
+        MatcherAssert.assertThat(
+            new TextOf(
+                new SkipInput(
+                    new InputOf(
+                        new JoinedText(
+                            delimiter,
+                            prefix,
+                            suffix
+                        )
+                    ),
+                    new BytesOf(delimiter)
+                )
+            ).asString(),
+            Matchers.equalTo(suffix)
+        );
+    }
+
+    @Test
+    public void skipsEverythingWhenNoDelimiter() throws Exception {
+        MatcherAssert.assertThat(
+            new TextOf(
+                new SkipInput(
+                    new InputOf("Hello, dude! How are you?"),
+                    new BytesOf("\n")
+                )
+            ).asString(),
+            Matchers.equalTo("")
+        );
+    }
+
+    @Test
+    public void skipsEverythingWhenEndingWithDelimiter() throws Exception {
+        final String delimiter = "\r\n";
+        MatcherAssert.assertThat(
+            new TextOf(
+                new SkipInput(
+                    new InputOf(
+                        new JoinedText(
+                            "",
+                            "Hello dude! How are you?",
+                            delimiter
+                        )
+                    ),
+                    new BytesOf(delimiter)
+                )
+            ).asString(),
+            Matchers.equalTo("")
+        );
+    }
+}

--- a/src/test/java/org/cactoos/http/io/package-info.java
+++ b/src/test/java/org/cactoos/http/io/package-info.java
@@ -22,39 +22,11 @@
  * SOFTWARE.
  */
 
-package org.cactoos.http;
-
-import java.io.IOException;
-import java.io.InputStream;
-import org.cactoos.Input;
-import org.cactoos.http.io.SkipInput;
-import org.cactoos.io.BytesOf;
-
 /**
- * Head of HTTP response.
+ * Io for Http, tests.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
  * @author Victor Noel (victor.noel@crazydwarves.org)
  * @version $Id$
  * @since 0.1
  */
-public final class HtBody implements Input {
-
-    /**
-     * Response.
-     */
-    private final Input response;
-
-    /**
-     * Ctor.
-     * @param rsp Response
-     */
-    public HtBody(final Input rsp) {
-        this.response = rsp;
-    }
-
-    @Override
-    public InputStream stream() throws IOException {
-        return new SkipInput(this.response, new BytesOf("\r\n\r\n")).stream();
-    }
-}
+package org.cactoos.http.io;


### PR DESCRIPTION
This is for #3.

This involves skipping everything in the response stream until the delimiter before the body is met and then returning the stream as-is. See discussions in #29 for rationale behind this.