### PR TITLE
HtTimedWire #10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@ SOFTWARE.
     <dependency>
       <groupId>org.cactoos</groupId>
       <artifactId>cactoos</artifactId>
-      <version>0.29.2</version>
+      <version>0.30</version>
     </dependency>
     <dependency>
       <groupId>org.takes</groupId>

--- a/src/main/java/org/cactoos/http/HtTimedWire.java
+++ b/src/main/java/org/cactoos/http/HtTimedWire.java
@@ -1,0 +1,70 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.cactoos.http;
+
+import java.io.IOException;
+import org.cactoos.Input;
+import org.cactoos.func.IoCheckedFunc;
+import org.cactoos.func.TimedFunc;
+
+/**
+ * {@link Wire} that will terminate the connection if it's taking too long.
+ *
+ * @author Victor Noel (victor.noel@crazydwarves.org)
+ * @version $Id$
+ * @since 0.1
+ */
+public final class HtTimedWire implements Wire {
+
+    /**
+     * Original wire.
+     */
+    private final Wire origin;
+
+    /**
+     * Milliseconds.
+     */
+    private final long milliseconds;
+
+    /**
+     * Ctor.
+     * @param wire Original wire
+     * @param milliseconds Milliseconds until the connection is terminated
+     */
+    public HtTimedWire(final Wire wire, final long milliseconds) {
+        this.origin = wire;
+        this.milliseconds = milliseconds;
+    }
+
+    @Override
+    public Input send(final Input input) throws IOException {
+        return new IoCheckedFunc<>(
+            new TimedFunc<>(
+                this.origin::send,
+                this.milliseconds
+            )
+        ).apply(input);
+    }
+}

--- a/src/test/java/org/cactoos/http/HtTimedWireTest.java
+++ b/src/test/java/org/cactoos/http/HtTimedWireTest.java
@@ -1,0 +1,111 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.http;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.concurrent.TimeoutException;
+import org.cactoos.io.InputOf;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.JoinedText;
+import org.cactoos.text.TextOf;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.takes.http.FtRemote;
+import org.takes.tk.TkText;
+
+/**
+ * Test case for {@link HtTimedWire}.
+ *
+ * @author Victor Noel (victor.noel@crazydwarves.org)
+ * @version $Id$
+ * @since 0.1
+ * @checkstyle JavadocMethodCheck (500 lines)
+ * @checkstyle JavadocVariableCheck (500 lines)
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
+ */
+public final class HtTimedWireTest {
+
+    @Rule
+    public final ExpectedException expected = ExpectedException.none();
+
+    private ServerSocket server;
+
+    @Before
+    public void openServerWithOneSlot() throws Exception {
+        this.server = new ServerSocket(0, 1);
+    }
+
+    @After
+    public void closeServer() throws Exception {
+        this.server.close();
+    }
+
+    @Test
+    public void worksFine() throws Exception {
+        // @checkstyle MagicNumberCheck (1 line)
+        final long timeout = 1000;
+        new FtRemote(new TkText("Hello, world!")).exec(
+            home -> MatcherAssert.assertThat(
+                new TextOf(
+                    new HtResponse(
+                        new HtTimedWire(new HtWire(home), timeout),
+                        new JoinedText(
+                            "\r\n",
+                            "GET / HTTP/1.1",
+                            new FormattedText("Host:%s", home.getHost())
+                                .asString()
+                        ).asString()
+                    )
+                ).asString(),
+                Matchers.containsString("HTTP/1.1 200 ")
+            )
+        );
+    }
+
+    // @checkstyle MagicNumberCheck (1 line)
+    @Test(timeout = 1000)
+    public void failsAfterTimeout() throws Exception {
+        // @checkstyle MagicNumberCheck (1 line)
+        final long timeout = 100;
+        this.expected.expect(IOException.class);
+        this.expected.expectCause(Matchers.instanceOf(TimeoutException.class));
+        try (Socket blocker = new Socket()) {
+            blocker.connect(this.server.getLocalSocketAddress());
+            new HtTimedWire(
+                new HtWire(
+                    this.server.getInetAddress().getHostAddress(),
+                    this.server.getLocalPort()
+                ),
+                timeout
+            ).send(new InputOf("unused"));
+        }
+    }
+}


### PR DESCRIPTION
This is for #10.

`HtTimedWire` terminates the connection if takes too much time.
It is based on `TimedFunc` which interrupts a function after a timeout.
The interrupt terminates the socket connection of the original `Wire`.

Dependency to cactoos is bumped to 0.30 (for `TimedFunc`).