### PR TITLE
#39 Use cactoos FormattedText instead of static String format.

### DIFF
--- a/src/main/java/org/cactoos/http/HtResponse.java
+++ b/src/main/java/org/cactoos/http/HtResponse.java
@@ -29,6 +29,8 @@ import java.io.InputStream;
 import java.net.URI;
 import org.cactoos.Input;
 import org.cactoos.io.InputOf;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 
 /**
  * Response.
@@ -66,12 +68,14 @@ public final class HtResponse implements Input {
     public HtResponse(final URI uri) {
         this(
             new HtWire(uri),
-            String.format(
-                "GET %s HTTP/1.1\r\nHost:%s",
-                // @checkstyle AvoidInlineConditionalsCheck (1 line)
-                uri.getQuery() == null ? "/" : uri.getQuery(),
-                uri.getHost()
-            )
+            new UncheckedText(
+                new FormattedText(
+                    "GET %s HTTP/1.1\r\nHost:%s",
+                    // @checkstyle AvoidInlineConditionalsCheck (1 line)
+                    uri.getQuery() == null ? "/" : uri.getQuery(),
+                    uri.getHost()
+                )
+            ).asString()
         );
     }
 

--- a/src/test/java/org/cactoos/http/HtAutoRedirectTest.java
+++ b/src/test/java/org/cactoos/http/HtAutoRedirectTest.java
@@ -27,7 +27,6 @@ import org.cactoos.io.InputOf;
 import org.cactoos.text.FormattedText;
 import org.cactoos.text.JoinedText;
 import org.cactoos.text.TextOf;
-import org.cactoos.text.UncheckedText;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -41,7 +40,6 @@ import org.takes.tk.TkText;
  * @version $Id$
  * @since 0.1
  * @checkstyle JavadocMethodCheck (500 lines)
- * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 public final class HtAutoRedirectTest {
 
@@ -56,10 +54,8 @@ public final class HtAutoRedirectTest {
                             new JoinedText(
                                 "\r\n",
                                 "HTTP/1.1 301",
-                                new UncheckedText(
-                                    new FormattedText(
-                                        "Location: %s", home
-                                    )
+                                new FormattedText(
+                                    "Location: %s", home
                                 ).asString()
                             )
                         )

--- a/src/test/java/org/cactoos/http/HtAutoRedirectTest.java
+++ b/src/test/java/org/cactoos/http/HtAutoRedirectTest.java
@@ -24,8 +24,10 @@
 package org.cactoos.http;
 
 import org.cactoos.io.InputOf;
+import org.cactoos.text.FormattedText;
 import org.cactoos.text.JoinedText;
 import org.cactoos.text.TextOf;
+import org.cactoos.text.UncheckedText;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -39,6 +41,7 @@ import org.takes.tk.TkText;
  * @version $Id$
  * @since 0.1
  * @checkstyle JavadocMethodCheck (500 lines)
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 public final class HtAutoRedirectTest {
 
@@ -53,7 +56,11 @@ public final class HtAutoRedirectTest {
                             new JoinedText(
                                 "\r\n",
                                 "HTTP/1.1 301",
-                                String.format("Location: %s", home)
+                                new UncheckedText(
+                                    new FormattedText(
+                                        "Location: %s", home
+                                    )
+                                ).asString()
                             )
                         )
                     )

--- a/src/test/java/org/cactoos/http/HtResponseTest.java
+++ b/src/test/java/org/cactoos/http/HtResponseTest.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 import org.cactoos.text.FormattedText;
 import org.cactoos.text.JoinedText;
 import org.cactoos.text.TextOf;
-import org.cactoos.text.UncheckedText;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -55,11 +54,9 @@ public final class HtResponseTest {
                         new JoinedText(
                             "\r\n",
                             "GET / HTTP/1.1",
-                                new UncheckedText(
-                                    new FormattedText(
-                                        "Host:%s", home.getHost()
-                                    )
-                                ).asString()
+                            new FormattedText(
+                                "Host:%s", home.getHost()
+                            ).asString()
                         ).asString()
                     )
                 ).asString(),

--- a/src/test/java/org/cactoos/http/HtResponseTest.java
+++ b/src/test/java/org/cactoos/http/HtResponseTest.java
@@ -24,8 +24,10 @@
 package org.cactoos.http;
 
 import java.io.IOException;
+import org.cactoos.text.FormattedText;
 import org.cactoos.text.JoinedText;
 import org.cactoos.text.TextOf;
+import org.cactoos.text.UncheckedText;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -53,7 +55,11 @@ public final class HtResponseTest {
                         new JoinedText(
                             "\r\n",
                             "GET / HTTP/1.1",
-                            String.format("Host:%s", home.getHost())
+                                new UncheckedText(
+                                    new FormattedText(
+                                        "Host:%s", home.getHost()
+                                    )
+                                ).asString()
                         ).asString()
                     )
                 ).asString(),

--- a/src/test/java/org/cactoos/http/HtSecureWireTest.java
+++ b/src/test/java/org/cactoos/http/HtSecureWireTest.java
@@ -32,7 +32,6 @@ import org.cactoos.io.InputOf;
 import org.cactoos.text.FormattedText;
 import org.cactoos.text.JoinedText;
 import org.cactoos.text.TextOf;
-import org.cactoos.text.UncheckedText;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -134,11 +133,9 @@ public final class HtSecureWireTest {
                 new JoinedText(
                     delimiter,
                     "GET / HTTP/1.1",
-                    new UncheckedText(
-                        new FormattedText(
-                            "Host: %s",
-                            this.host
-                        )
+                    new FormattedText(
+                        "Host: %s",
+                        this.host
                     ).asString(),
                     "Connection: close",
                     delimiter

--- a/src/test/java/org/cactoos/http/HtSecureWireTest.java
+++ b/src/test/java/org/cactoos/http/HtSecureWireTest.java
@@ -29,8 +29,10 @@ import java.net.ServerSocket;
 import javax.net.ssl.SSLServerSocketFactory;
 import org.cactoos.Input;
 import org.cactoos.io.InputOf;
+import org.cactoos.text.FormattedText;
 import org.cactoos.text.JoinedText;
 import org.cactoos.text.TextOf;
+import org.cactoos.text.UncheckedText;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -132,7 +134,12 @@ public final class HtSecureWireTest {
                 new JoinedText(
                     delimiter,
                     "GET / HTTP/1.1",
-                    String.format("Host: %s", this.host),
+                    new UncheckedText(
+                        new FormattedText(
+                            "Host: %s",
+                            this.host
+                        )
+                    ).asString(),
                     "Connection: close",
                     delimiter
                 )

--- a/src/test/java/org/cactoos/http/HtWireTest.java
+++ b/src/test/java/org/cactoos/http/HtWireTest.java
@@ -29,8 +29,10 @@ import java.net.URI;
 import org.cactoos.BiFunc;
 import org.cactoos.io.DeadInput;
 import org.cactoos.io.DeadInputStream;
+import org.cactoos.text.FormattedText;
 import org.cactoos.text.JoinedText;
 import org.cactoos.text.TextOf;
+import org.cactoos.text.UncheckedText;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -78,7 +80,12 @@ public final class HtWireTest {
                         new JoinedText(
                             "\r\n",
                             "GET / HTTP/1.1",
-                            String.format("Host:%s", home.getHost())
+                            new UncheckedText(
+                                new FormattedText(
+                                    "Host:%s",
+                                    home.getHost()
+                                )
+                            ).asString()
                         ).asString()
                     )
                 ).asString(),

--- a/src/test/java/org/cactoos/http/HtWireTest.java
+++ b/src/test/java/org/cactoos/http/HtWireTest.java
@@ -32,7 +32,6 @@ import org.cactoos.io.DeadInputStream;
 import org.cactoos.text.FormattedText;
 import org.cactoos.text.JoinedText;
 import org.cactoos.text.TextOf;
-import org.cactoos.text.UncheckedText;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -80,11 +79,9 @@ public final class HtWireTest {
                         new JoinedText(
                             "\r\n",
                             "GET / HTTP/1.1",
-                            new UncheckedText(
-                                new FormattedText(
-                                    "Host:%s",
-                                    home.getHost()
-                                )
+                            new FormattedText(
+                                "Host:%s",
+                                home.getHost()
                             ).asString()
                         ).asString()
                     )


### PR DESCRIPTION
Let's use OOP primitives from cactoos for string formatting.
As per #39