### PR TITLE
Upgrade qulice to 0.17.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,6 +161,10 @@ SOFTWARE.
             <version>0.17.3</version>
             <configuration>
               <excludes combine.children="append">
+                <!--
+                  @todo #49:30min we should re-enable findbugs and fix all problems it detects.
+                   This mainly concerns for now reliance on default encoding in HtStatus.
+                -->
                 <exclude>findbugs:.*</exclude>
               </excludes>
             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -158,10 +158,9 @@ SOFTWARE.
           <plugin>
             <groupId>com.qulice</groupId>
             <artifactId>qulice-maven-plugin</artifactId>
-            <version>0.17.1</version>
+            <version>0.17.3</version>
             <configuration>
               <excludes combine.children="append">
-                <exclude>checkstyle:/src/site/resources/.*</exclude>
                 <exclude>findbugs:.*</exclude>
               </excludes>
             </configuration>

--- a/src/main/java/org/cactoos/http/HtAutoRedirect.java
+++ b/src/main/java/org/cactoos/http/HtAutoRedirect.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2018 Yegor Bugayenko
@@ -35,8 +35,6 @@ import org.cactoos.scalar.IoCheckedScalar;
 /**
  * Automatically redirects request if response status code is 30x.
  *
- * @author Vedran Vatavuk (123vgv@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 public final class HtAutoRedirect implements Input {

--- a/src/main/java/org/cactoos/http/HtBody.java
+++ b/src/main/java/org/cactoos/http/HtBody.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2018 Yegor Bugayenko
@@ -32,10 +32,7 @@ import org.cactoos.io.BytesOf;
 
 /**
  * Head of HTTP response.
- *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @author Victor Noel (victor.noel@crazydwarves.org)
- * @version $Id$
+
  * @since 0.1
  */
 public final class HtBody implements Input {

--- a/src/main/java/org/cactoos/http/HtContentType.java
+++ b/src/main/java/org/cactoos/http/HtContentType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2018 Yegor Bugayenko
@@ -38,8 +38,6 @@ import org.cactoos.list.ListOf;
  * a missing <code>content-type</code> header is interpreted as
  * <code>application/octet-stream</code></p>
  *
- * @author Victor Noel (victor.noel@crazydwarves.org)
- * @version $Id$
  * @since 0.1
  */
 public final class HtContentType implements Scalar<List<String>> {

--- a/src/main/java/org/cactoos/http/HtCookies.java
+++ b/src/main/java/org/cactoos/http/HtCookies.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2018 Yegor Bugayenko
@@ -38,8 +38,6 @@ import org.cactoos.text.SplitText;
 /**
  * Cookies.
  *
- * @author Vseslav Sekorin (vssekorin@gmail.com)
- * @version $Id$
  * @since 0.1
  * @todo #8:30min The implementation of method stream() will break on
  *  "flag-type" directives (`Secure`, `HttpOnly`). Fix HtHeaders so that

--- a/src/main/java/org/cactoos/http/HtHead.java
+++ b/src/main/java/org/cactoos/http/HtHead.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2018 Yegor Bugayenko
@@ -34,8 +34,6 @@ import org.cactoos.io.InputStreamOf;
 /**
  * Head of HTTP response.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 public final class HtHead implements Input {

--- a/src/main/java/org/cactoos/http/HtHeaders.java
+++ b/src/main/java/org/cactoos/http/HtHeaders.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2018 Yegor Bugayenko
@@ -41,8 +41,6 @@ import org.cactoos.text.TrimmedText;
 /**
  * Headers of HTTP response.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 public final class HtHeaders extends MapEnvelope<String, List<String>> {

--- a/src/main/java/org/cactoos/http/HtResponse.java
+++ b/src/main/java/org/cactoos/http/HtResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2018 Yegor Bugayenko
@@ -35,8 +35,6 @@ import org.cactoos.text.UncheckedText;
 /**
  * Response.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 public final class HtResponse implements Input {

--- a/src/main/java/org/cactoos/http/HtRetryWire.java
+++ b/src/main/java/org/cactoos/http/HtRetryWire.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2018 Yegor Bugayenko
@@ -35,8 +35,6 @@ import org.cactoos.func.RetryFunc;
  *
  * <p>There is no thread-safety guarantee.
  *
- * @author Victor Noel (victor.noel@crazydwarves.org)
- * @version $Id$
  * @since 0.1
  */
 public final class HtRetryWire implements Wire {

--- a/src/main/java/org/cactoos/http/HtSecureWire.java
+++ b/src/main/java/org/cactoos/http/HtSecureWire.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2018 Yegor Bugayenko
@@ -34,8 +34,6 @@ import org.cactoos.scalar.Constant;
 /**
  * Wire that supports https.
  *
- * @author Vedran Vatavuk (123vgv@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 public final class HtSecureWire implements Wire {

--- a/src/main/java/org/cactoos/http/HtStatus.java
+++ b/src/main/java/org/cactoos/http/HtStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2018 Yegor Bugayenko
@@ -32,8 +32,6 @@ import org.cactoos.scalar.NumberEnvelope;
 /**
  * Status of HTTP response.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 public final class HtStatus extends NumberEnvelope {

--- a/src/main/java/org/cactoos/http/HtTimedWire.java
+++ b/src/main/java/org/cactoos/http/HtTimedWire.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2018 Yegor Bugayenko
@@ -32,8 +32,6 @@ import org.cactoos.func.TimedFunc;
 /**
  * {@link Wire} that will terminate the connection if it's taking too long.
  *
- * @author Victor Noel (victor.noel@crazydwarves.org)
- * @version $Id$
  * @since 0.1
  */
 public final class HtTimedWire implements Wire {

--- a/src/main/java/org/cactoos/http/HtWire.java
+++ b/src/main/java/org/cactoos/http/HtWire.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2018 Yegor Bugayenko
@@ -42,8 +42,6 @@ import org.cactoos.scalar.Ternary;
 /**
  * Wire.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 public final class HtWire implements Wire {

--- a/src/main/java/org/cactoos/http/Wire.java
+++ b/src/main/java/org/cactoos/http/Wire.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2018 Yegor Bugayenko
@@ -30,8 +30,6 @@ import org.cactoos.Input;
 /**
  * Wire.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 public interface Wire {

--- a/src/main/java/org/cactoos/http/io/BoundedByteBuffer.java
+++ b/src/main/java/org/cactoos/http/io/BoundedByteBuffer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2018 Yegor Bugayenko
@@ -32,8 +32,6 @@ import org.cactoos.scalar.UncheckedScalar;
 /**
  * A very simple circular buffer of bytes.
  *
- * @author Victor Noel (victor.noel@crazydwarves.org)
- * @version $Id$
  * @since 0.1
  */
 public final class BoundedByteBuffer {

--- a/src/main/java/org/cactoos/http/io/SkipInput.java
+++ b/src/main/java/org/cactoos/http/io/SkipInput.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2018 Yegor Bugayenko
@@ -32,8 +32,6 @@ import org.cactoos.Input;
 /**
  * {@link Input} that skips until it find some defined bytes.
  *
- * @author Victor Noel (victor.noel@crazydwarves.org)
- * @version $Id$
  * @since 0.1
  */
 public final class SkipInput implements Input {

--- a/src/main/java/org/cactoos/http/io/package-info.java
+++ b/src/main/java/org/cactoos/http/io/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2018 Yegor Bugayenko
@@ -25,8 +25,6 @@
 /**
  * Io for Http.
  *
- * @author Victor Noel (victor.noel@crazydwarves.org)
- * @version $Id$
  * @since 0.1
  */
 package org.cactoos.http.io;

--- a/src/main/java/org/cactoos/http/package-info.java
+++ b/src/main/java/org/cactoos/http/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2018 Yegor Bugayenko
@@ -25,8 +25,6 @@
 /**
  * Http.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 package org.cactoos.http;

--- a/src/test/java/org/cactoos/http/HtAutoRedirectTest.java
+++ b/src/test/java/org/cactoos/http/HtAutoRedirectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2018 Yegor Bugayenko
@@ -36,8 +36,6 @@ import org.takes.tk.TkText;
 /**
  * Test case for {@link HtAutoRedirect}.
  *
- * @author Vedran Vatavuk (123vgv@gmail.com)
- * @version $Id$
  * @since 0.1
  * @checkstyle JavadocMethodCheck (500 lines)
  */

--- a/src/test/java/org/cactoos/http/HtBodyTest.java
+++ b/src/test/java/org/cactoos/http/HtBodyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2018 Yegor Bugayenko
@@ -34,8 +34,6 @@ import org.junit.Test;
 /**
  * Test case for {@link HtBody}.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)

--- a/src/test/java/org/cactoos/http/HtContentTypeTest.java
+++ b/src/test/java/org/cactoos/http/HtContentTypeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2018 Yegor Bugayenko
@@ -33,8 +33,6 @@ import org.junit.Test;
 /**
  * Test case for {@link HtContentType}.
  *
- * @author Victor Noel (victor.noel@crazydwarves.org)
- * @version $Id$
  * @since 0.1
  * @checkstyle JavadocMethodCheck (500 lines)
  */

--- a/src/test/java/org/cactoos/http/HtCookiesTest.java
+++ b/src/test/java/org/cactoos/http/HtCookiesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2018 Yegor Bugayenko
@@ -34,8 +34,6 @@ import org.junit.Test;
 /**
  * Test case for {@link HtCookies}.
  *
- * @author Vseslav Sekorin (vssekorin@gmail.com)
- * @version $Id$
  * @since 0.1
  * @checkstyle JavadocMethodCheck (500 lines)
  */

--- a/src/test/java/org/cactoos/http/HtHeadTest.java
+++ b/src/test/java/org/cactoos/http/HtHeadTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2018 Yegor Bugayenko
@@ -36,8 +36,6 @@ import org.junit.Test;
 /**
  * Test case for {@link HtHead}.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)

--- a/src/test/java/org/cactoos/http/HtHeadersTest.java
+++ b/src/test/java/org/cactoos/http/HtHeadersTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2018 Yegor Bugayenko
@@ -34,8 +34,6 @@ import org.junit.Test;
 /**
  * Test case for {@link HtHeaders}.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)

--- a/src/test/java/org/cactoos/http/HtResponseTest.java
+++ b/src/test/java/org/cactoos/http/HtResponseTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2018 Yegor Bugayenko
@@ -36,8 +36,6 @@ import org.takes.tk.TkText;
 /**
  * Test case for {@link HtResponse}.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)

--- a/src/test/java/org/cactoos/http/HtRetryWireTest.java
+++ b/src/test/java/org/cactoos/http/HtRetryWireTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2018 Yegor Bugayenko
@@ -39,8 +39,6 @@ import org.junit.rules.ExpectedException;
 /**
  * Test case for {@link HtRetryWire}.
  *
- * @author Victor Noel (victor.noel@crazydwarves.org)
- * @version $Id$
  * @since 0.1
  * @checkstyle JavadocMethodCheck (500 lines)
  */

--- a/src/test/java/org/cactoos/http/HtSecureWireTest.java
+++ b/src/test/java/org/cactoos/http/HtSecureWireTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2018 Yegor Bugayenko
@@ -43,8 +43,6 @@ import org.takes.tk.TkText;
 /**
  * Test case for {@link HtSecureWire}.
  *
- * @author Vedran Vatavuk (123vgv@gmail.com)
- * @version $Id$
  * @since 0.1
  * @checkstyle JavadocMethodCheck (500 lines)
  */

--- a/src/test/java/org/cactoos/http/HtStatusTest.java
+++ b/src/test/java/org/cactoos/http/HtStatusTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2018 Yegor Bugayenko
@@ -34,8 +34,6 @@ import org.junit.Test;
 /**
  * Test case for {@link HtStatus}.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)

--- a/src/test/java/org/cactoos/http/HtTimedWireTest.java
+++ b/src/test/java/org/cactoos/http/HtTimedWireTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2018 Yegor Bugayenko
@@ -44,8 +44,6 @@ import org.takes.tk.TkText;
 /**
  * Test case for {@link HtTimedWire}.
  *
- * @author Victor Noel (victor.noel@crazydwarves.org)
- * @version $Id$
  * @since 0.1
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle JavadocVariableCheck (500 lines)

--- a/src/test/java/org/cactoos/http/HtWireTest.java
+++ b/src/test/java/org/cactoos/http/HtWireTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2018 Yegor Bugayenko
@@ -41,8 +41,7 @@ import org.takes.tk.TkText;
 
 /**
  * Test case for {@link HtWire}.
- * @author Krzysztof Krason (Krzysztof.Krason@gmail.com)
- * @version $Id$
+ *
  * @since 0.1
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)

--- a/src/test/java/org/cactoos/http/io/BoundedByteBufferTest.java
+++ b/src/test/java/org/cactoos/http/io/BoundedByteBufferTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2018 Yegor Bugayenko
@@ -31,8 +31,6 @@ import org.junit.Test;
 /**
  * Test case for {@link BoundedByteBuffer}.
  *
- * @author Victor Noel (victor.noel@crazydwarves.org)
- * @version $Id$
  * @since 0.1
  * @checkstyle JavadocMethodCheck (500 lines)
  */

--- a/src/test/java/org/cactoos/http/io/SkipInputTest.java
+++ b/src/test/java/org/cactoos/http/io/SkipInputTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2018 Yegor Bugayenko
@@ -35,8 +35,6 @@ import org.junit.Test;
 /**
  * Test case for {@link SkipInput}.
  *
- * @author Victor Noel (victor.noel@crazydwarves.org)
- * @version $Id$
  * @since 0.1
  * @checkstyle JavadocMethodCheck (500 lines)
  */

--- a/src/test/java/org/cactoos/http/io/package-info.java
+++ b/src/test/java/org/cactoos/http/io/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2018 Yegor Bugayenko
@@ -25,8 +25,6 @@
 /**
  * Io for Http, tests.
  *
- * @author Victor Noel (victor.noel@crazydwarves.org)
- * @version $Id$
  * @since 0.1
  */
 package org.cactoos.http.io;

--- a/src/test/java/org/cactoos/http/package-info.java
+++ b/src/test/java/org/cactoos/http/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2018 Yegor Bugayenko
@@ -25,8 +25,6 @@
 /**
  * HTTP client, tests.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 package org.cactoos.http;


### PR DESCRIPTION
For #49

This upgrades qulice to 0.17.3 and fix all the errors: remove prohibited `@version` `@author` and change opening comment for licence header.

Also removed an unused configuration property (referenced directory doesn't exist) and added a `@todo` to reenable findbugs (please check this @llorllale).