### PR TITLE
#42 HtHead can be broken

### DIFF
--- a/src/main/java/org/cactoos/http/HtHead.java
+++ b/src/main/java/org/cactoos/http/HtHead.java
@@ -27,7 +27,9 @@ package org.cactoos.http;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.SequenceInputStream;
+import java.util.Arrays;
 import org.cactoos.Input;
+import org.cactoos.http.io.StateMachine;
 import org.cactoos.io.DeadInputStream;
 import org.cactoos.io.InputStreamOf;
 
@@ -37,6 +39,11 @@ import org.cactoos.io.InputStreamOf;
  * @author Yegor Bugayenko (yegor256@gmail.com)
  * @version $Id$
  * @since 0.1
+ * @todo #42:30min The implementation of method stream() too complex.
+ *  Looks like state machine is too low-level abstraction for such task,
+ *  and one more level of abstraction should be arrive.
+ *  We should remove all checkstyle and PMD exceptions here.
+ *  Be careful with previous buffer.
  */
 public final class HtHead implements Input {
 
@@ -52,57 +59,74 @@ public final class HtHead implements Input {
 
     /**
      * Ctor.
+     *
      * @param rsp Response
      */
     public HtHead(final Input rsp) {
         this.response = rsp;
     }
 
+    // @checkstyle NestedIfDepthCheck (500 lines)
+    // @checkstyle ExecutableStatementCountCheck (500 lines)
     @Override
-    @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
+    @SuppressWarnings(
+        {"PMD.AvoidInstantiatingObjectsInLoops", "PMD.NullAssignment"}
+    )
     public InputStream stream() throws IOException {
+        final byte[] pattern = {'\r', '\n', '\r', '\n'};
         final InputStream stream = this.response.stream();
         final byte[] buf = new byte[HtHead.LENGTH];
         InputStream head = new DeadInputStream();
+        StateMachine machine = new StateMachine(pattern);
+        byte[] old = null;
         while (true) {
             final int len = stream.read(buf);
-            if (len < 0) {
+            if (len <= 0) {
                 break;
             }
-            final int tail = HtHead.findEnd(buf, len);
-            final byte[] temp = new byte[tail];
-            System.arraycopy(buf, 0, temp, 0, tail);
-            head = new SequenceInputStream(head, new InputStreamOf(temp));
-            if (tail != len) {
-                break;
+            machine = machine.process(buf, len);
+            if (machine.finding()) {
+                if (machine.found()) {
+                    final int index = machine.getIndex();
+                    if (index >= 0) {
+                        if (old != null) {
+                            head = new SequenceInputStream(
+                                head,
+                                new InputStreamOf(old)
+                            );
+                        }
+                        if (index != 0) {
+                            head = new SequenceInputStream(
+                                head,
+                                new InputStreamOf(Arrays.copyOf(buf, index))
+                            );
+                        }
+                    } else {
+                        head = new SequenceInputStream(
+                            head,
+                            new InputStreamOf(
+                                Arrays.copyOf(old, old.length + index)
+                            )
+                        );
+                    }
+                    break;
+                } else {
+                    old = Arrays.copyOf(buf, len);
+                }
+            } else {
+                if (old != null) {
+                    head = new SequenceInputStream(
+                        head,
+                        new InputStreamOf(old)
+                    );
+                    old = null;
+                }
+                head = new SequenceInputStream(
+                    head,
+                    new InputStreamOf(Arrays.copyOf(buf, len))
+                );
             }
         }
         return head;
-    }
-
-    /**
-     * Find header end.
-     * @param buf Buffer where to search
-     * @param len Size of the buffer
-     * @return End of the header
-     */
-    private static int findEnd(final byte[] buf, final int len) {
-        final byte[] end = {'\r', '\n', '\r', '\n'};
-        int tail = end.length - 1;
-        while (tail < len) {
-            boolean found = true;
-            for (int num = 0; num < end.length; ++num) {
-                if (end[num] != buf[tail - end.length + 1 + num]) {
-                    found = false;
-                    break;
-                }
-            }
-            if (found) {
-                tail = tail - end.length + 1;
-                break;
-            }
-            ++tail;
-        }
-        return tail;
     }
 }

--- a/src/main/java/org/cactoos/http/io/StateMachine.java
+++ b/src/main/java/org/cactoos/http/io/StateMachine.java
@@ -1,0 +1,145 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.cactoos.http.io;
+
+/**
+ * Simple immutable finite-state machine for finding a specific pattern
+ * in a sequence of buffers.
+ *
+ * <p>There is thread-safety guarantee.
+ *
+ * @author Alexander Menshikov (sharplermc@gmail.com)
+ * @version $Id$
+ * @since 0.1
+ */
+public final class StateMachine {
+
+    /**
+     * The pattern for lookup.
+     */
+    private final byte[] pattern;
+
+    /**
+     * Current state.
+     */
+    private final int state;
+
+    /**
+     * Position in the current or previous buffer where the pattern is
+     * starting.
+     */
+    private final int index;
+
+    /**
+     * Ctor.
+     *
+     * @param pattern Pattern for lookup.
+     */
+    public StateMachine(final byte[] pattern) {
+        this(pattern.clone(), 0, 0);
+    }
+
+    /**
+     * Ctor.
+     *
+     * @param pattern Pattern for lookup.
+     * @param state Next state.
+     * @param index Next index.
+     */
+    @SuppressWarnings("PMD.ArrayIsStoredDirectly")
+    private StateMachine(final byte[] pattern, final int state,
+        final int index) {
+        this.pattern = pattern;
+        this.state = state;
+        this.index = index;
+    }
+
+    /**
+     * Processing new buffer.
+     *
+     * @param buf New buffer.
+     * @param len Length.
+     * @return Machine with next state.
+     * @checkstyle NestedIfDepthCheck (500 lines)
+     * @checkstyle HiddenFieldCheck (500 lines)
+     */
+    public StateMachine process(final byte[] buf, final int len) {
+        int state = this.state;
+        int index = this.index;
+        if (state < this.pattern.length) {
+            for (int pos = 0; pos < buf.length && pos < len; ++pos) {
+                if (this.pattern[state] == buf[pos]) {
+                    ++state;
+                    if (state == this.pattern.length) {
+                        index = pos + 1 - this.pattern.length;
+                        break;
+                    }
+                } else {
+                    state = 0;
+                }
+            }
+        }
+        final StateMachine ans;
+        if (this.state == state && this.index == index) {
+            ans = this;
+        } else {
+            ans = new StateMachine(this.pattern, state, index);
+        }
+        return ans;
+    }
+
+    /**
+     * Check to at least part of the pattern was found.
+     *
+     * @return Return {@code True} if at least part of the pattern was found.
+     */
+    public boolean finding() {
+        return this.state > 0;
+    }
+
+    /**
+     * Check to the pattern was found.
+     *
+     * @return Return {@code true} if the pattern was found.
+     */
+    public boolean found() {
+        return this.state == this.pattern.length;
+    }
+
+    /**
+     * Return index in the current or previous buffer where the pattern is
+     * starting.
+     *
+     * @return If positive then return position in the current buffer where the
+     *  pattern is starting. If negative then return position from the end of
+     *  the previous buffer.
+     */
+    public int getIndex() {
+        if (!this.found()) {
+            throw new IllegalStateException("Should be in terminal state.");
+        }
+        return this.index;
+    }
+}

--- a/src/test/java/org/cactoos/http/HtHeadTest.java
+++ b/src/test/java/org/cactoos/http/HtHeadTest.java
@@ -24,9 +24,11 @@
 package org.cactoos.http;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.Random;
 import org.cactoos.io.BytesOf;
 import org.cactoos.io.InputOf;
+import org.cactoos.matchers.MatcherOf;
 import org.cactoos.text.JoinedText;
 import org.cactoos.text.TextOf;
 import org.hamcrest.MatcherAssert;
@@ -41,6 +43,7 @@ import org.junit.Test;
  * @since 0.1
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
+ * @checkstyle MagicNumberCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class HtHeadTest {
@@ -86,7 +89,6 @@ public final class HtHeadTest {
 
     @Test
     public void largeText() throws IOException {
-        //@checkstyle MagicNumberCheck (1 lines)
         final byte[] bytes = new byte[18000];
         new Random().nextBytes(bytes);
         MatcherAssert.assertThat(
@@ -107,4 +109,138 @@ public final class HtHeadTest {
         );
     }
 
+    @Test
+    public void attackInTheMiddle() throws IOException {
+        final int size = 16384;
+        final ByteBuffer buf = ByteBuffer.allocate(size * 2);
+        for (int pos = 0; pos < size - 4; ++pos) {
+            buf.put((byte) 'a');
+        }
+        buf.put((byte) 'b');
+        buf.put((byte) '\r');
+        buf.put((byte) '\n');
+        buf.put((byte) '\r');
+        buf.put((byte) '\n');
+        for (int pos = buf.position(); pos < 2 * size; ++pos) {
+            buf.put((byte) 'a');
+        }
+        MatcherAssert.assertThat(
+            "Can't find when separator broken by two buffers",
+            new TextOf(
+                new HtHead(
+                    new InputOf(
+                        new TextOf(new BytesOf(buf.array())).asString()
+                    )
+                )
+            ).asString(),
+            Matchers.endsWith("b")
+        );
+    }
+
+    @Test
+    public void attackOnBufferStart() throws IOException {
+        final int size = 16384;
+        final ByteBuffer buf = ByteBuffer.allocate(size * 2);
+        for (int pos = 0; pos < size - 1; ++pos) {
+            buf.put((byte) 'a');
+        }
+        buf.put((byte) 'b');
+        buf.put((byte) '\r');
+        buf.put((byte) '\n');
+        buf.put((byte) '\r');
+        buf.put((byte) '\n');
+        for (int pos = buf.position(); pos < 2 * size; ++pos) {
+            buf.put((byte) 'a');
+        }
+        MatcherAssert.assertThat(
+            "Can't find when buffers starts from separator",
+            new TextOf(
+                new HtHead(
+                    new InputOf(
+                        new TextOf(new BytesOf(buf.array())).asString()
+                    )
+                )
+            ).asString(),
+            Matchers.endsWith("b")
+        );
+    }
+
+    @Test
+    public void fakeSeparator() throws IOException {
+        final int size = 16384;
+        final ByteBuffer buf = ByteBuffer.allocate(size * 2);
+        for (int pos = 0; pos < size - 2; ++pos) {
+            buf.put((byte) 'a');
+        }
+        buf.put((byte) '\r');
+        buf.put((byte) '\n');
+        for (int pos = size; pos < 2 * size - 5; ++pos) {
+            buf.put((byte) 'a');
+        }
+        buf.put((byte) 'b');
+        buf.put((byte) '\r');
+        buf.put((byte) '\n');
+        buf.put((byte) '\r');
+        buf.put((byte) '\n');
+        MatcherAssert.assertThat(
+            "Can't add previous buffer with part of separator",
+            new TextOf(
+                new HtHead(
+                    new InputOf(
+                        new TextOf(new BytesOf(buf.array())).asString()
+                    )
+                )
+            ).asString(),
+            new MatcherOf<>(
+                str -> str.length() == size * 2 - 4 && str.endsWith("b")
+            )
+        );
+    }
+
+    @Test
+    public void rollbackState() throws IOException {
+        final int size = 16384;
+        final ByteBuffer buf = ByteBuffer.allocate(size * 4);
+        for (int pos = 0; pos < 2 * size - 2; ++pos) {
+            buf.put((byte) 'a');
+        }
+        buf.put((byte) '\r');
+        buf.put((byte) '\n');
+        for (int pos = 2 * size; pos < 4 * size - 5; ++pos) {
+            buf.put((byte) 'a');
+        }
+        buf.put((byte) 'b');
+        buf.put((byte) '\r');
+        buf.put((byte) '\n');
+        buf.put((byte) '\r');
+        buf.put((byte) '\n');
+        MatcherAssert.assertThat(
+            "Can't rollback state to initial state",
+            new TextOf(
+                new HtHead(
+                    new InputOf(
+                        new TextOf(new BytesOf(buf.array())).asString()
+                    )
+                )
+            ).asString(),
+            new MatcherOf<>(
+                str -> str.length() == size * 4 - 4 && str.endsWith("b")
+            )
+        );
+    }
+
+    @Test
+    public void checkEmptyInput() throws IOException {
+        MatcherAssert.assertThat(
+            "Can't process empty input",
+            new TextOf(
+                new HtHead(
+                    new InputOf(
+                        ""
+                    )
+                )
+            ).asString(),
+            Matchers.isEmptyString()
+        );
+    }
 }

--- a/src/test/java/org/cactoos/http/io/StateMachineTest.java
+++ b/src/test/java/org/cactoos/http/io/StateMachineTest.java
@@ -1,0 +1,54 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.http.io;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+/**
+ * Test case for {@link StateMachine}.
+ *
+ * @author Alexander Menshikov (sharplermc@gmail.com)
+ * @version $Id$
+ * @since 0.1
+ * @checkstyle JavadocMethodCheck (500 lines)
+ */
+public final class StateMachineTest {
+    @Test(expected = IllegalStateException.class)
+    public void indexInNotFinalState() {
+        new StateMachine(new byte[] {1, 2}).getIndex();
+    }
+
+    @Test
+    public void holdingOnFinalState() {
+        StateMachine machine = new StateMachine(new byte[] {1, 2});
+        final byte[] buf = {-1, 0, 1, 2};
+        machine = machine.process(buf, buf.length);
+        MatcherAssert.assertThat(
+            machine.process(new byte[] {1, 2}, 2),
+            Matchers.equalTo(machine)
+        );
+    }
+}


### PR DESCRIPTION
For #42 

**Problem:**
HtHead can miss the separator `\r\n\r\n` when it split by two buffers.
**Solution**
Fix it by using a state machine.

Code a bit complex, I have added a puzzle to fix it.