### PR TITLE
#59 re-enable findbugs with fix of default encoding reliance in HtStatus

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,15 +165,6 @@ SOFTWARE.
             <groupId>com.qulice</groupId>
             <artifactId>qulice-maven-plugin</artifactId>
             <version>0.17.3</version>
-            <configuration>
-              <excludes combine.children="append">
-                <!--
-                  @todo #49:30min we should re-enable findbugs and fix all problems it detects.
-                   This mainly concerns for now reliance on default encoding in HtStatus.
-                -->
-                <exclude>findbugs:.*</exclude>
-              </excludes>
-            </configuration>
           </plugin>
           <plugin>
             <groupId>org.jacoco</groupId>

--- a/src/main/java/org/cactoos/http/HtStatus.java
+++ b/src/main/java/org/cactoos/http/HtStatus.java
@@ -26,6 +26,7 @@ package org.cactoos.http;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import org.cactoos.Input;
 import org.cactoos.scalar.NumberEnvelope;
 
@@ -49,7 +50,7 @@ public final class HtStatus extends NumberEnvelope {
         super(() -> Double.parseDouble(
             // @checkstyle MagicNumber (3 line)
             new BufferedReader(
-                new InputStreamReader(head.stream())
+                new InputStreamReader(head.stream(), StandardCharsets.UTF_8)
             ).readLine().split(" ", 3)[1]
         ));
     }


### PR DESCRIPTION
#59

- re-enable findbugs with fix of default encoding reliance in `HtStatus`