### PR TITLE
#20: Add HtKeepAliveResponse for support of Keep-Alive header

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@ SOFTWARE.
     <dependency>
       <groupId>org.llorllale</groupId>
       <artifactId>cactoos-matchers</artifactId>
-      <version>0.11</version>
+      <version>0.13</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/org/cactoos/http/HtKeepAliveResponse.java
+++ b/src/main/java/org/cactoos/http/HtKeepAliveResponse.java
@@ -70,19 +70,6 @@ public final class HtKeepAliveResponse implements Input {
      * @param mtimeout The timeout for the connection usage in milliseconds
      * @param rmax The maximum quantity of the requests within the connection
      *  timeout
-     */
-    public HtKeepAliveResponse(
-        final String uri, final long mtimeout, final int rmax
-    ) {
-        this(URI.create(uri), mtimeout, rmax);
-    }
-
-    /**
-     * Ctor.
-     * @param uri Target URI
-     * @param mtimeout The timeout for the connection usage in milliseconds
-     * @param rmax The maximum quantity of the requests within the connection
-     *  timeout
      * @todo #20:30min Replace the HtWire by HtKeepAliveWire which should
      *  support the <em>Keep-Alive</em> header. It should has at least 1 `ctor`
      *  with 3 parameters:
@@ -103,9 +90,7 @@ public final class HtKeepAliveResponse implements Input {
                     HtKeepAliveResponse.TEMPLATE,
                     new UncheckedScalar<>(
                         new Ternary<>(
-                            () -> uri.getQuery() == null,
-                            () -> "/",
-                            uri::getQuery
+                            uri.getQuery() == null, "/", uri.getQuery()
                         )
                     ),
                     uri.getHost(),

--- a/src/main/java/org/cactoos/http/HtKeepAliveResponse.java
+++ b/src/main/java/org/cactoos/http/HtKeepAliveResponse.java
@@ -26,14 +26,12 @@ package org.cactoos.http;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.util.Optional;
 import org.cactoos.Input;
 import org.cactoos.Text;
 import org.cactoos.io.InputOf;
-import org.cactoos.scalar.Ternary;
-import org.cactoos.scalar.UncheckedScalar;
 import org.cactoos.text.FormattedText;
 import org.cactoos.text.JoinedText;
-import org.cactoos.text.UncheckedText;
 
 /**
  * The response which supports <em>Keep-Alive</em> header.
@@ -76,8 +74,8 @@ public final class HtKeepAliveResponse implements Input {
      *  - `wire` which represents the HTTP connection;
      *  - `timeout` in milliseconds;
      *  - `rmax` the max quantity of within the timeout.
-     *  In case if the quantity of requests more than `rmax` but takes less than
-     *  `timeout`, the connection should be reset by the server.
+     *  In case the quantity of requests is greater than rmax but takes less
+     *  time than `timeout`, the connection should be reset by the server.
      *  Remove the suppresing of PMD errors due to unused private fields.
      */
     public HtKeepAliveResponse(
@@ -85,19 +83,13 @@ public final class HtKeepAliveResponse implements Input {
     ) {
         this(
             new HtWire(uri),
-            new UncheckedText(
                 new FormattedText(
                     HtKeepAliveResponse.TEMPLATE,
-                    new UncheckedScalar<>(
-                        new Ternary<>(
-                            uri.getQuery() == null, "/", uri.getQuery()
-                        )
-                    ),
+                    Optional.ofNullable(uri.getQuery()).orElse("/"),
                     uri.getHost(),
                     mtimeout,
                     rmax
-                )
-            ).asString(),
+                ),
             mtimeout,
             rmax
         );
@@ -113,7 +105,7 @@ public final class HtKeepAliveResponse implements Input {
      * @checkstyle ParameterNumberCheck (5 lines)
      */
     public HtKeepAliveResponse(
-        final Wire wire, final String req, final long mtimeout, final int rmax
+        final Wire wire, final Text req, final long mtimeout, final int rmax
     ) {
         this(wire, new InputOf(req), mtimeout, rmax);
     }

--- a/src/main/java/org/cactoos/http/HtKeepAliveResponse.java
+++ b/src/main/java/org/cactoos/http/HtKeepAliveResponse.java
@@ -23,8 +23,6 @@
  */
 package org.cactoos.http;
 
-import java.io.IOException;
-import java.io.InputStream;
 import java.net.URI;
 import java.util.Optional;
 import org.cactoos.Input;
@@ -38,7 +36,7 @@ import org.cactoos.text.JoinedText;
  *
  * @since 0.1
  */
-public final class HtKeepAliveResponse implements Input {
+public final class HtKeepAliveResponse extends HtResponseEnvelope {
 
     /**
      * The template of GET request which supports the <em>Keep-Alive</em>
@@ -51,16 +49,6 @@ public final class HtKeepAliveResponse implements Input {
         "Connection: Keep-Alive",
         "Keep-Alive: timeout=%s, max=%s"
     );
-
-    /**
-     * The wire.
-     */
-    private final Wire wire;
-
-    /**
-     * HTTP request.
-     */
-    private final Input request;
 
     /**
      * Ctor.
@@ -83,13 +71,13 @@ public final class HtKeepAliveResponse implements Input {
     ) {
         this(
             new HtWire(uri),
-                new FormattedText(
-                    HtKeepAliveResponse.TEMPLATE,
-                    Optional.ofNullable(uri.getQuery()).orElse("/"),
-                    uri.getHost(),
-                    mtimeout,
-                    rmax
-                ),
+            new FormattedText(
+                HtKeepAliveResponse.TEMPLATE,
+                Optional.ofNullable(uri.getQuery()).orElse("/"),
+                uri.getHost(),
+                mtimeout,
+                rmax
+            ),
             mtimeout,
             rmax
         );
@@ -123,13 +111,7 @@ public final class HtKeepAliveResponse implements Input {
     public HtKeepAliveResponse(
         final Wire wire, final Input req, final long mtimeout, final int rmax
     ) {
-        this.wire = wire;
-        this.request = req;
-    }
-
-    @Override
-    public InputStream stream() throws IOException {
-        return this.wire.send(this.request).stream();
+        super(wire, req);
     }
 
 }

--- a/src/main/java/org/cactoos/http/HtKeepAliveResponse.java
+++ b/src/main/java/org/cactoos/http/HtKeepAliveResponse.java
@@ -77,9 +77,7 @@ public final class HtKeepAliveResponse extends HtResponseEnvelope {
                 uri.getHost(),
                 mtimeout,
                 rmax
-            ),
-            mtimeout,
-            rmax
+            )
         );
     }
 
@@ -87,30 +85,18 @@ public final class HtKeepAliveResponse extends HtResponseEnvelope {
      * Ctor.
      * @param wire The wire
      * @param req The request
-     * @param mtimeout The timeout for the connection usage in milliseconds
-     * @param rmax The maximum quantity of the requests within the connection
      *  timeout
-     * @checkstyle ParameterNumberCheck (5 lines)
      */
-    public HtKeepAliveResponse(
-        final Wire wire, final Text req, final long mtimeout, final int rmax
-    ) {
-        this(wire, new InputOf(req), mtimeout, rmax);
+    public HtKeepAliveResponse(final Wire wire, final Text req) {
+        this(wire, new InputOf(req));
     }
 
     /**
      * Ctor.
      * @param wire The wire
      * @param req The request
-     * @param mtimeout The timeout for the connection usage in milliseconds
-     * @param rmax The maximum quantity of the requests within the connection
-     *  timeout
-     * @checkstyle ParameterNumberCheck (5 lines)
      */
-    @SuppressWarnings("PMD.UnusedFormalParameter")
-    public HtKeepAliveResponse(
-        final Wire wire, final Input req, final long mtimeout, final int rmax
-    ) {
+    public HtKeepAliveResponse(final Wire wire, final Input req) {
         super(new HtResponse(wire, req));
     }
 

--- a/src/main/java/org/cactoos/http/HtKeepAliveResponse.java
+++ b/src/main/java/org/cactoos/http/HtKeepAliveResponse.java
@@ -111,7 +111,7 @@ public final class HtKeepAliveResponse extends HtResponseEnvelope {
     public HtKeepAliveResponse(
         final Wire wire, final Input req, final long mtimeout, final int rmax
     ) {
-        super(wire, req);
+        super(new HtResponse(wire, req));
     }
 
 }

--- a/src/main/java/org/cactoos/http/HtKeepAliveResponse.java
+++ b/src/main/java/org/cactoos/http/HtKeepAliveResponse.java
@@ -1,0 +1,158 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.http;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import org.cactoos.Input;
+import org.cactoos.Text;
+import org.cactoos.io.InputOf;
+import org.cactoos.scalar.Ternary;
+import org.cactoos.scalar.UncheckedScalar;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.JoinedText;
+import org.cactoos.text.UncheckedText;
+
+/**
+ * The response which supports <em>Keep-Alive</em> header.
+ *
+ * @since 0.1
+ */
+public final class HtKeepAliveResponse implements Input {
+
+    /**
+     * The template of GET request which supports the <em>Keep-Alive</em>
+     * header.
+     */
+    private static final Text TEMPLATE = new JoinedText(
+        "\r\n",
+        "GET %s HTTP/1.1",
+        "Host:%s",
+        "Connection: Keep-Alive",
+        "Keep-Alive: timeout=%s, max=%s"
+    );
+
+    /**
+     * The wire.
+     */
+    private final Wire wire;
+
+    /**
+     * HTTP request.
+     */
+    private final Input request;
+
+    /**
+     * Ctor.
+     * @param uri Target URI
+     * @param mtimeout The timeout for the connection usage in milliseconds
+     * @param rmax The maximum quantity of the requests within the connection
+     *  timeout
+     */
+    public HtKeepAliveResponse(
+        final String uri, final long mtimeout, final int rmax
+    ) {
+        this(URI.create(uri), mtimeout, rmax);
+    }
+
+    /**
+     * Ctor.
+     * @param uri Target URI
+     * @param mtimeout The timeout for the connection usage in milliseconds
+     * @param rmax The maximum quantity of the requests within the connection
+     *  timeout
+     * @todo #20:30min Replace the HtWire by HtKeepAliveWire which should
+     *  support the <em>Keep-Alive</em> header. It should has at least 1 `ctor`
+     *  with 3 parameters:
+     *  - `wire` which represents the HTTP connection;
+     *  - `timeout` in milliseconds;
+     *  - `rmax` the max quantity of within the timeout.
+     *  In case if the quantity of requests more than `rmax` but takes less than
+     *  `timeout`, the connection should be reset by the server.
+     *  Remove the suppresing of PMD errors due to unused private fields.
+     */
+    public HtKeepAliveResponse(
+        final URI uri, final long mtimeout, final int rmax
+    ) {
+        this(
+            new HtWire(uri),
+            new UncheckedText(
+                new FormattedText(
+                    HtKeepAliveResponse.TEMPLATE,
+                    new UncheckedScalar<>(
+                        new Ternary<>(
+                            () -> uri.getQuery() == null,
+                            () -> "/",
+                            uri::getQuery
+                        )
+                    ),
+                    uri.getHost(),
+                    mtimeout,
+                    rmax
+                )
+            ).asString(),
+            mtimeout,
+            rmax
+        );
+    }
+
+    /**
+     * Ctor.
+     * @param wire The wire
+     * @param req The request
+     * @param mtimeout The timeout for the connection usage in milliseconds
+     * @param rmax The maximum quantity of the requests within the connection
+     *  timeout
+     * @checkstyle ParameterNumberCheck (5 lines)
+     */
+    public HtKeepAliveResponse(
+        final Wire wire, final String req, final long mtimeout, final int rmax
+    ) {
+        this(wire, new InputOf(req), mtimeout, rmax);
+    }
+
+    /**
+     * Ctor.
+     * @param wire The wire
+     * @param req The request
+     * @param mtimeout The timeout for the connection usage in milliseconds
+     * @param rmax The maximum quantity of the requests within the connection
+     *  timeout
+     * @checkstyle ParameterNumberCheck (5 lines)
+     */
+    @SuppressWarnings("PMD.UnusedFormalParameter")
+    public HtKeepAliveResponse(
+        final Wire wire, final Input req, final long mtimeout, final int rmax
+    ) {
+        this.wire = wire;
+        this.request = req;
+    }
+
+    @Override
+    public InputStream stream() throws IOException {
+        return this.wire.send(this.request).stream();
+    }
+
+}

--- a/src/main/java/org/cactoos/http/HtKeepAliveResponse.java
+++ b/src/main/java/org/cactoos/http/HtKeepAliveResponse.java
@@ -25,7 +25,6 @@ package org.cactoos.http;
 
 import java.net.URI;
 import java.util.Optional;
-import org.cactoos.Input;
 import org.cactoos.Text;
 import org.cactoos.io.InputOf;
 import org.cactoos.text.FormattedText;
@@ -69,35 +68,19 @@ public final class HtKeepAliveResponse extends HtResponseEnvelope {
     public HtKeepAliveResponse(
         final URI uri, final long mtimeout, final int rmax
     ) {
-        this(
-            new HtWire(uri),
-            new FormattedText(
-                HtKeepAliveResponse.TEMPLATE,
-                Optional.ofNullable(uri.getQuery()).orElse("/"),
-                uri.getHost(),
-                mtimeout,
-                rmax
+        super(
+            new HtResponse(
+                new HtWire(uri),
+                new InputOf(
+                    new FormattedText(
+                        HtKeepAliveResponse.TEMPLATE,
+                        Optional.ofNullable(uri.getQuery()).orElse("/"),
+                        uri.getHost(),
+                        mtimeout,
+                        rmax
+                    )
+                )
             )
         );
     }
-
-    /**
-     * Ctor.
-     * @param wire The wire
-     * @param req The request
-     *  timeout
-     */
-    public HtKeepAliveResponse(final Wire wire, final Text req) {
-        this(wire, new InputOf(req));
-    }
-
-    /**
-     * Ctor.
-     * @param wire The wire
-     * @param req The request
-     */
-    public HtKeepAliveResponse(final Wire wire, final Input req) {
-        super(new HtResponse(wire, req));
-    }
-
 }

--- a/src/main/java/org/cactoos/http/HtResponse.java
+++ b/src/main/java/org/cactoos/http/HtResponse.java
@@ -24,8 +24,6 @@
 
 package org.cactoos.http;
 
-import java.io.IOException;
-import java.io.InputStream;
 import java.net.URI;
 import org.cactoos.Input;
 import org.cactoos.io.InputOf;
@@ -41,17 +39,7 @@ import org.cactoos.text.UncheckedText;
  *  on criteria like the Content-Length header, the Transfer-Encoding header
  *  (when service returns the payload in chunks), etc.
  */
-public final class HtResponse implements Input {
-
-    /**
-     * The wire.
-     */
-    private final Wire wire;
-
-    /**
-     * HTTP request.
-     */
-    private final Input request;
+public final class HtResponse extends HtResponseEnvelope {
 
     /**
      * Ctor.
@@ -96,12 +84,7 @@ public final class HtResponse implements Input {
      * @param req The request
      */
     public HtResponse(final Wire wre, final Input req) {
-        this.wire = wre;
-        this.request = req;
+        super(wre, req);
     }
 
-    @Override
-    public InputStream stream() throws IOException {
-        return this.wire.send(this.request).stream();
-    }
 }

--- a/src/main/java/org/cactoos/http/HtResponse.java
+++ b/src/main/java/org/cactoos/http/HtResponse.java
@@ -84,7 +84,7 @@ public final class HtResponse extends HtResponseEnvelope {
      * @param req The request
      */
     public HtResponse(final Wire wre, final Input req) {
-        super(wre, req);
+        super(() -> wre.send(req).stream());
     }
 
 }

--- a/src/main/java/org/cactoos/http/HtResponseEnvelope.java
+++ b/src/main/java/org/cactoos/http/HtResponseEnvelope.java
@@ -1,0 +1,62 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.cactoos.http;
+
+import java.io.IOException;
+import java.io.InputStream;
+import org.cactoos.Input;
+
+/**
+ * The envelope for HTTP response.
+ *
+ * @since 0.1
+ */
+public class HtResponseEnvelope implements Input {
+
+    /**
+     * The wire.
+     */
+    private final Wire wire;
+
+    /**
+     * HTTP request.
+     */
+    private final Input request;
+
+    /**
+     * Ctor.
+     * @param wre The wire
+     * @param req The request
+     */
+    public HtResponseEnvelope(final Wire wre, final Input req) {
+        this.wire = wre;
+        this.request = req;
+    }
+
+    @Override
+    public final InputStream stream() throws IOException {
+        return this.wire.send(this.request).stream();
+    }
+}

--- a/src/main/java/org/cactoos/http/HtResponseEnvelope.java
+++ b/src/main/java/org/cactoos/http/HtResponseEnvelope.java
@@ -33,30 +33,23 @@ import org.cactoos.Input;
  *
  * @since 0.1
  */
-public class HtResponseEnvelope implements Input {
-
-    /**
-     * The wire.
-     */
-    private final Wire wire;
+public abstract class HtResponseEnvelope implements Input {
 
     /**
      * HTTP request.
      */
-    private final Input request;
+    private final Input origin;
 
     /**
      * Ctor.
-     * @param wre The wire
-     * @param req The request
+     * @param origin The request
      */
-    public HtResponseEnvelope(final Wire wre, final Input req) {
-        this.wire = wre;
-        this.request = req;
+    public HtResponseEnvelope(final Input origin) {
+        this.origin = origin;
     }
 
     @Override
     public final InputStream stream() throws IOException {
-        return this.wire.send(this.request).stream();
+        return this.origin.stream();
     }
 }

--- a/src/test/java/org/cactoos/http/HtKeepAliveResponseTest.java
+++ b/src/test/java/org/cactoos/http/HtKeepAliveResponseTest.java
@@ -1,0 +1,54 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.http;
+
+import java.io.IOException;
+import org.cactoos.text.TextOf;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.StringContains;
+import org.junit.Test;
+import org.takes.http.FtRemote;
+import org.takes.tk.TkText;
+
+/**
+ * Test case for {@link HtKeepAliveResponse}.
+ *
+ * @since 0.1
+ * @checkstyle MagicNumberCheck (500 lines)
+ * @checkstyle JavadocMethodCheck (500 lines)
+ */
+public final class HtKeepAliveResponseTest {
+
+    @Test
+    public void worksFineByUri() throws IOException {
+        new FtRemote(new TkText("Hello, dude!")).exec(
+            home -> MatcherAssert.assertThat(
+                new TextOf(
+                    new HtKeepAliveResponse(home, 5000, 5)
+                ).asString(),
+                new StringContains("HTTP/1.1 200 OK")
+            )
+        );
+    }
+}

--- a/src/test/java/org/cactoos/http/HtKeepAliveResponseTest.java
+++ b/src/test/java/org/cactoos/http/HtKeepAliveResponseTest.java
@@ -25,8 +25,8 @@ package org.cactoos.http;
 
 import java.io.IOException;
 import org.cactoos.text.TextOf;
-import org.hamcrest.MatcherAssert;
 import org.junit.Test;
+import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.TextHasString;
 import org.takes.http.FtRemote;
 import org.takes.tk.TkText;
@@ -43,12 +43,13 @@ public final class HtKeepAliveResponseTest {
     @Test
     public void worksFineByUri() throws IOException {
         new FtRemote(new TkText("Hello, dude!")).exec(
-            home -> MatcherAssert.assertThat(
-                new TextOf(
+            home -> new Assertion<>(
+                "The HTTP response contains 200 status code",
+                () -> new TextOf(
                     new HtKeepAliveResponse(home, 5000, 5)
                 ),
                 new TextHasString("HTTP/1.1 200 OK")
-            )
+            ).affirm()
         );
     }
 }

--- a/src/test/java/org/cactoos/http/HtKeepAliveResponseTest.java
+++ b/src/test/java/org/cactoos/http/HtKeepAliveResponseTest.java
@@ -26,8 +26,8 @@ package org.cactoos.http;
 import java.io.IOException;
 import org.cactoos.text.TextOf;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.core.StringContains;
 import org.junit.Test;
+import org.llorllale.cactoos.matchers.TextHasString;
 import org.takes.http.FtRemote;
 import org.takes.tk.TkText;
 
@@ -46,8 +46,8 @@ public final class HtKeepAliveResponseTest {
             home -> MatcherAssert.assertThat(
                 new TextOf(
                     new HtKeepAliveResponse(home, 5000, 5)
-                ).asString(),
-                new StringContains("HTTP/1.1 200 OK")
+                ),
+                new TextHasString("HTTP/1.1 200 OK")
             )
         );
     }


### PR DESCRIPTION
This PR for #20 contains:
 - Skeleton for HtKeepAliveResponse
 - 1 todo task for implementation of HtKeepAliveWire