### PR TITLE
Update BoundedByteBuffer

### DIFF
--- a/src/main/java/org/cactoos/http/io/BoundedByteBuffer.java
+++ b/src/main/java/org/cactoos/http/io/BoundedByteBuffer.java
@@ -56,7 +56,6 @@ public final class BoundedByteBuffer {
      */
     private boolean full;
 
-
     /**
      * Ctor.
      *
@@ -78,7 +77,7 @@ public final class BoundedByteBuffer {
     public void offer(final byte add) {
         this.internal[this.idx] = add;
         this.idx = (this.idx + 1) % this.limit;
-        if (this.idx == 0){
+        if (this.idx == 0) {
             this.full = true;
         }
     }
@@ -92,24 +91,27 @@ public final class BoundedByteBuffer {
      */
     public boolean equalTo(final byte[] bytes) {
         boolean result;
-        if (this.full){
+        if (this.full) {
             result = bytes.length == this.internal.length;
-            for (int i=this.idx; i<this.internal.length; i++){
-                if (!result)
+            for (int idx = this.idx; idx < this.internal.length; idx += 1) {
+                if (!result) {
                     break;
-                result = bytes[i-this.idx] == this.internal[i];
+                }
+                result = bytes[idx - this.idx] == this.internal[idx];
             }
-            for (int i=0; i<this.idx-1; i++){
-                if (!result)
+            for (int idx = 0; idx<this.idx - 1; idx += 1) {
+                if (!result) {
                     break;
-                result = bytes[i+this.idx-1] == this.internal[i];
+                }
+                result = bytes[idx + this.idx - 1] == this.internal[idx];
             }
         } else {
             result = bytes.length == this.idx;
-            for (int i=0; i<this.idx-1; i++){
-                if (!result)
+            for (int idx = 0; idx < this.idx - 1; idx += 1) {
+                if (!result) {
                     break;
-                result = bytes[i] == this.internal[i];
+                }
+                result = bytes[idx] == this.internal[idx];
             }
         }
         return result;

--- a/src/main/java/org/cactoos/http/io/BoundedByteBuffer.java
+++ b/src/main/java/org/cactoos/http/io/BoundedByteBuffer.java
@@ -36,11 +36,6 @@ public final class BoundedByteBuffer {
     private final byte[] internal;
 
     /**
-     * The size limit.
-     */
-    private final int limit;
-
-    /**
      * Current buffer index.
      */
     private int idx;
@@ -56,8 +51,7 @@ public final class BoundedByteBuffer {
      * @param limit The size limit.
      */
     BoundedByteBuffer(final int limit) {
-        this.limit = limit;
-        this.internal = new byte[this.limit];
+        this.internal = new byte[limit];
         this.idx = 0;
         this.full = false;
     }
@@ -70,7 +64,7 @@ public final class BoundedByteBuffer {
      */
     public void offer(final byte add) {
         this.internal[this.idx] = add;
-        this.idx = (this.idx + 1) % this.limit;
+        this.idx = (this.idx + 1) % this.internal.length;
         if (this.idx == 0) {
             this.full = true;
         }

--- a/src/main/java/org/cactoos/http/io/BoundedByteBuffer.java
+++ b/src/main/java/org/cactoos/http/io/BoundedByteBuffer.java
@@ -76,7 +76,7 @@ public final class BoundedByteBuffer {
      * @param bytes The bytes to compare to.
      * @return The value {@code true} if the buffer contains exactly
      *  the {@code bytes}.
-     * @todo #60:30min Figure out a more elegant way to compare 
+     * @todo #60:30min Figure out a more elegant way to compare
      *  the ring buffer imitation to another buffer,
      *  and avoid the for loop hell that is in the following method.
      */

--- a/src/main/java/org/cactoos/http/io/BoundedByteBuffer.java
+++ b/src/main/java/org/cactoos/http/io/BoundedByteBuffer.java
@@ -76,6 +76,8 @@ public final class BoundedByteBuffer {
      * @param bytes The bytes to compare to.
      * @return The value {@code true} if the buffer contains exactly
      *  the {@code bytes}.
+     * @todo #60:30min Figure out a more elegant way to compare 
+     *  the ring buffer imitation to another buffer.
      */
     public boolean equalTo(final byte[] bytes) {
         boolean result;

--- a/src/main/java/org/cactoos/http/io/BoundedByteBuffer.java
+++ b/src/main/java/org/cactoos/http/io/BoundedByteBuffer.java
@@ -22,13 +22,7 @@
  * SOFTWARE.
  */
 package org.cactoos.http.io;
-/*
-import java.util.Arrays;
-import org.cactoos.Bytes;
-import org.cactoos.io.BytesOf;
-import org.cactoos.scalar.Equality;
-import org.cactoos.scalar.UncheckedScalar;
-*/
+
 /**
  * A very simple circular buffer of bytes.
  *

--- a/src/main/java/org/cactoos/http/io/BoundedByteBuffer.java
+++ b/src/main/java/org/cactoos/http/io/BoundedByteBuffer.java
@@ -92,21 +92,12 @@ public final class BoundedByteBuffer {
      */
     public boolean equalTo(final byte[] bytes) {
         final int result;
-        if (this.current < this.limit) {
-            result = new UncheckedScalar<>(
-                new Equality<Bytes>(
-                    new BytesOf(Arrays.copyOf(this.internal, this.current)),
-                    new BytesOf(bytes)
-                )
-            ).value();
-        } else {
-            result = new UncheckedScalar<>(
-                new Equality<Bytes>(
-                    new BytesOf(this.internal),
-                    new BytesOf(bytes)
-                )
-            ).value();
-        }
+        result = new UncheckedScalar<>(
+            new Equality<Bytes>(
+                new BytesOf(currentState()),
+                new BytesOf(bytes)
+            )
+        ).value();
         return result == 0;
     }
 

--- a/src/main/java/org/cactoos/http/io/BoundedByteBuffer.java
+++ b/src/main/java/org/cactoos/http/io/BoundedByteBuffer.java
@@ -47,9 +47,15 @@ public final class BoundedByteBuffer {
     private final int limit;
 
     /**
-     * Current size of buffer.
+     * Current buffer index.
      */
-    private int current;
+    private int idx;
+
+    /**
+     * Is the buffer full?
+     */
+    private boolean full;
+
 
     /**
      * Ctor.
@@ -59,7 +65,8 @@ public final class BoundedByteBuffer {
     BoundedByteBuffer(final int limit) {
         this.limit = limit;
         this.internal = new byte[this.limit];
-        this.current = 0;
+        this.idx = 0;
+        this.full = false;
     }
 
     /**
@@ -69,14 +76,11 @@ public final class BoundedByteBuffer {
      * @param add The byte to add
      */
     public void offer(final byte add) {
-        if (this.current == this.limit) {
-            System.arraycopy(
-                this.internal, 1, this.internal, 0, this.limit - 1
-            );
-        } else {
-            ++this.current;
+        this.internal[this.idx] = add;
+        this.idx = (this.idx + 1) % this.limit;
+        if (this.idx == 0){
+            this.full = true;
         }
-        this.internal[this.current - 1] = add;
     }
 
     /**

--- a/src/main/java/org/cactoos/http/io/BoundedByteBuffer.java
+++ b/src/main/java/org/cactoos/http/io/BoundedByteBuffer.java
@@ -77,7 +77,8 @@ public final class BoundedByteBuffer {
      * @return The value {@code true} if the buffer contains exactly
      *  the {@code bytes}.
      * @todo #60:30min Figure out a more elegant way to compare 
-     *  the ring buffer imitation to another buffer.
+     *  the ring buffer imitation to another buffer,
+     *  and avoid the for loop hell that is in the following method.
      */
     public boolean equalTo(final byte[] bytes) {
         boolean result;

--- a/src/main/java/org/cactoos/http/io/BoundedByteBuffer.java
+++ b/src/main/java/org/cactoos/http/io/BoundedByteBuffer.java
@@ -91,28 +91,27 @@ public final class BoundedByteBuffer {
      *  the {@code bytes}.
      */
     public boolean equalTo(final byte[] bytes) {
-        final int result;
-        result = new UncheckedScalar<>(
-            new Equality<Bytes>(
-                new BytesOf(currentState()),
-                new BytesOf(bytes)
-            )
-        ).value();
-        return result == 0;
-    }
-
-    private byte[] currentState(){
+        boolean result;
         if (this.full){
-            byte[] state = new byte[this.internal.length];
-            if (this.internal.length - this.idx >= 0)
-                System.arraycopy(this.internal, this.idx, state, 0, this.internal.length - this.idx);
-            if (this.idx >= 0)
-                System.arraycopy(this.internal, 0, state, this.idx, this.idx);
-            return state;
+            result = bytes.length == this.internal.length;
+            for (int i=this.idx; i<this.internal.length; i++){
+                if (!result)
+                    break;
+                result = bytes[i-this.idx] == this.internal[i];
+            }
+            for (int i=0; i<this.idx-1; i++){
+                if (!result)
+                    break;
+                result = bytes[i+this.idx-1] == this.internal[i];
+            }
         } else {
-            byte[] state = new byte[this.idx];
-            System.arraycopy(this.internal, 0, state, 0, this.idx);
-            return state;
+            result = bytes.length == this.idx;
+            for (int i=0; i<this.idx-1; i++){
+                if (!result)
+                    break;
+                result = bytes[i] == this.internal[i];
+            }
         }
+        return result;
     }
 }

--- a/src/main/java/org/cactoos/http/io/BoundedByteBuffer.java
+++ b/src/main/java/org/cactoos/http/io/BoundedByteBuffer.java
@@ -23,11 +23,13 @@
  */
 package org.cactoos.http.io;
 
+/*
 import java.util.Arrays;
 import org.cactoos.Bytes;
 import org.cactoos.io.BytesOf;
 import org.cactoos.scalar.Equality;
 import org.cactoos.scalar.UncheckedScalar;
+*/
 
 /**
  * A very simple circular buffer of bytes.
@@ -93,26 +95,27 @@ public final class BoundedByteBuffer {
         boolean result;
         if (this.full) {
             result = bytes.length == this.internal.length;
-            for (int idx = this.idx; idx < this.internal.length; idx += 1) {
+            for (int idn = this.idx; idn < this.internal.length; idn += 1) {
                 if (!result) {
                     break;
                 }
-                result = bytes[idx - this.idx] == this.internal[idx];
+                result = bytes[idn - this.idx] == this.internal[idn];
             }
-            for (int idx = 0; idx<this.idx - 1; idx += 1) {
+            for (int idn = 0; idn < this.idx - 1; idn += 1) {
                 if (!result) {
                     break;
                 }
-                result = bytes[idx + this.idx - 1] == this.internal[idx];
+                result = bytes[idn + this.idx - 1] == this.internal[idn];
             }
         } else {
             result = bytes.length == this.idx;
-            for (int idx = 0; idx < this.idx - 1; idx += 1) {
+            for (int idn = 0; idn < this.idx - 1; idn += 1) {
                 if (!result) {
                     break;
                 }
-                result = bytes[idx] == this.internal[idx];
+                result = bytes[idn] == this.internal[idn];
             }
+
         }
         return result;
     }

--- a/src/main/java/org/cactoos/http/io/BoundedByteBuffer.java
+++ b/src/main/java/org/cactoos/http/io/BoundedByteBuffer.java
@@ -109,4 +109,19 @@ public final class BoundedByteBuffer {
         }
         return result == 0;
     }
+
+    private byte[] currentState(){
+        if (this.full){
+            byte[] state = new byte[this.internal.length];
+            if (this.internal.length - this.idx >= 0)
+                System.arraycopy(this.internal, this.idx, state, 0, this.internal.length - this.idx);
+            if (this.idx >= 0)
+                System.arraycopy(this.internal, 0, state, this.idx, this.idx);
+            return state;
+        } else {
+            byte[] state = new byte[this.idx];
+            System.arraycopy(this.internal, 0, state, 0, this.idx);
+            return state;
+        }
+    }
 }

--- a/src/main/java/org/cactoos/http/io/BoundedByteBuffer.java
+++ b/src/main/java/org/cactoos/http/io/BoundedByteBuffer.java
@@ -22,7 +22,6 @@
  * SOFTWARE.
  */
 package org.cactoos.http.io;
-
 /*
 import java.util.Arrays;
 import org.cactoos.Bytes;
@@ -30,7 +29,6 @@ import org.cactoos.io.BytesOf;
 import org.cactoos.scalar.Equality;
 import org.cactoos.scalar.UncheckedScalar;
 */
-
 /**
  * A very simple circular buffer of bytes.
  *
@@ -115,7 +113,6 @@ public final class BoundedByteBuffer {
                 }
                 result = bytes[idn] == this.internal[idn];
             }
-
         }
         return result;
     }


### PR DESCRIPTION
Updated offer method to not copy the whole array when overwriting old bytes.
Added a new private method, currentState, which returns an array of bytes in the oldest to newest order.
Updated equalTo method to respect the new way the class works internally.

Addresses #60 