### PR TITLE
(#64) HtAutoClosedResponse

### DIFF
--- a/src/main/java/org/cactoos/http/HtAutoClosedResponse.java
+++ b/src/main/java/org/cactoos/http/HtAutoClosedResponse.java
@@ -1,0 +1,55 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.cactoos.http;
+
+import java.io.InputStream;
+import org.cactoos.Input;
+import org.cactoos.http.io.AutoClosedInputStream;
+
+/**
+ * Response that gets closed on EOF.
+ *
+ * @since 0.1
+ */
+public final class HtAutoClosedResponse implements Input {
+
+    /**
+     * The origin response.
+     */
+    private final Input origin;
+
+    /**
+     * Ctor.
+     * @param rsp The origin response.
+     */
+    public HtAutoClosedResponse(final Input rsp) {
+        this.origin = rsp;
+    }
+
+    @Override
+    public InputStream stream() throws Exception {
+        return new AutoClosedInputStream(this.origin.stream());
+    }
+}

--- a/src/main/java/org/cactoos/http/HtResponse.java
+++ b/src/main/java/org/cactoos/http/HtResponse.java
@@ -34,10 +34,10 @@ import org.cactoos.text.UncheckedText;
  * Response.
  *
  * @since 0.1
- * @todo #62:30min We need decorators for HtResponse that will automatically
- *  close the inputstream (therefore also closing the network socket) based
- *  on criteria like the Content-Length header, the Transfer-Encoding header
- *  (when service returns the payload in chunks), etc.
+ * @todo #64:30min We need decorators for HtResponse that will automatically
+ *  transform the inputstream based on criteria like the Content-Length header,
+ *  the Transfer-Encoding header (when service returns the payload in chunks),
+ *  etc.
  */
 public final class HtResponse extends InputEnvelope {
 

--- a/src/main/java/org/cactoos/http/io/AutoClosedInputStream.java
+++ b/src/main/java/org/cactoos/http/io/AutoClosedInputStream.java
@@ -1,0 +1,129 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.http.io;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * {@link InputStream} that gets closed on EOF.
+ *
+ * @since 0.1
+ */
+public final class AutoClosedInputStream extends InputStream {
+
+    /**
+     * The original input.
+     */
+    private final InputStream origin;
+
+    /**
+     * If the stream has been closed.
+     */
+    private boolean closed;
+
+    /**
+     * Cotr.
+     *
+     * @param origin The origin input.
+     */
+    public AutoClosedInputStream(final InputStream origin) {
+        super();
+        this.origin = origin;
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (!this.closed) {
+            this.origin.close();
+            this.closed = true;
+        }
+    }
+
+    @Override
+    public int available() throws IOException {
+        return this.origin.available();
+    }
+
+    @Override
+    public int read(final byte[] bytes, final int off, final int len)
+        throws IOException {
+        return new AutoClosed(() -> this.origin.read(bytes, off, len)).value();
+    }
+
+    @Override
+    public int read(final byte[] bytes) throws IOException {
+        return new AutoClosed(() -> this.origin.read(bytes)).value();
+    }
+
+    @Override
+    public int read() throws IOException {
+        return new AutoClosed(() -> this.origin.read()).value();
+    }
+
+    /**
+     * Primitive Scalar.
+     */
+    private interface IntScalar {
+        /**
+         * Convert it to the value.
+         * @return The value
+         * @throws IOException If fails
+         */
+        int value() throws IOException;
+    }
+
+    /**
+     * Closes the stream if EOF is reached.
+     */
+    private final class AutoClosed implements IntScalar {
+
+        /**
+         * The read on the stream.
+         */
+        private final IntScalar origin;
+
+        /**
+         * Ctor.
+         * @param origin The read of the stream.
+         */
+        AutoClosed(final IntScalar origin) {
+            this.origin = origin;
+        }
+
+        @Override
+        public int value() throws IOException {
+            final int ret;
+            if (AutoClosedInputStream.this.closed) {
+                ret = -1;
+            } else {
+                ret = this.origin.value();
+                if (ret < 0) {
+                    AutoClosedInputStream.this.close();
+                }
+            }
+            return ret;
+        }
+    }
+}

--- a/src/main/java/org/cactoos/http/io/AutoClosedInputStream.java
+++ b/src/main/java/org/cactoos/http/io/AutoClosedInputStream.java
@@ -39,11 +39,6 @@ public final class AutoClosedInputStream extends InputStream {
     private final InputStream origin;
 
     /**
-     * If the stream has been closed.
-     */
-    private boolean closed;
-
-    /**
      * Cotr.
      *
      * @param origin The origin input.
@@ -55,10 +50,7 @@ public final class AutoClosedInputStream extends InputStream {
 
     @Override
     public void close() throws IOException {
-        if (!this.closed) {
-            this.origin.close();
-            this.closed = true;
-        }
+        this.origin.close();
     }
 
     @Override
@@ -115,13 +107,9 @@ public final class AutoClosedInputStream extends InputStream {
         @Override
         public int value() throws IOException {
             final int ret;
-            if (AutoClosedInputStream.this.closed) {
-                ret = -1;
-            } else {
-                ret = this.origin.value();
-                if (ret < 0) {
-                    AutoClosedInputStream.this.close();
-                }
+            ret = this.origin.value();
+            if (ret < 0) {
+                AutoClosedInputStream.this.close();
             }
             return ret;
         }

--- a/src/test/java/org/cactoos/http/Get.java
+++ b/src/test/java/org/cactoos/http/Get.java
@@ -35,13 +35,13 @@ import org.cactoos.text.TextOf;
  *
  * @since 0.1
  */
-public final class GetInput extends InputEnvelope {
+public final class Get extends InputEnvelope {
     /**
      * Ctor.
      *
      * @param url Url to GET.
      */
-    public GetInput(final URI url) {
+    public Get(final URI url) {
         super(new InputOf(
             new JoinedText(
                 new TextOf("\r\n"),

--- a/src/test/java/org/cactoos/http/GetInput.java
+++ b/src/test/java/org/cactoos/http/GetInput.java
@@ -23,50 +23,37 @@
  */
 package org.cactoos.http;
 
-import java.io.IOException;
+import java.net.URI;
+import org.cactoos.Input;
+import org.cactoos.io.InputOf;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.JoinedText;
 import org.cactoos.text.TextOf;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
-import org.junit.Test;
-import org.llorllale.cactoos.matchers.TextHasString;
-import org.takes.http.FtRemote;
-import org.takes.tk.TkText;
 
 /**
- * Test case for {@link HtResponse}.
+ * An {@link Input} to GET an HTTP URI.
  *
  * @since 0.1
- * @checkstyle JavadocMethodCheck (500 lines)
- * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
-@SuppressWarnings("PMD.AvoidDuplicateLiterals")
-public final class HtResponseTest {
-
-    @Test
-    public void worksFine() throws IOException {
-        new FtRemote(new TkText("Hello, world!")).exec(
-            home -> MatcherAssert.assertThat(
-                new TextOf(
-                    new HtResponse(
-                        new HtWire(home),
-                        new GetInput(home)
-                    )
+public final class GetInput extends InputEnvelope {
+    /**
+     * Ctor.
+     *
+     * @param url Url to GET.
+     */
+    public GetInput(final URI url) {
+        super(new InputOf(
+            new JoinedText(
+                new TextOf("\r\n"),
+                new FormattedText(
+                    "GET %s HTTP/1.1",
+                    url.getPath()
                 ),
-                new TextHasString("HTTP/1.1 200 OK")
+                new FormattedText(
+                    "Host:%s",
+                    url.getHost()
+                )
             )
-        );
+        ));
     }
-
-    @Test
-    public void worksFineByUri() throws IOException {
-        new FtRemote(new TkText("Hello, dude!")).exec(
-            home -> MatcherAssert.assertThat(
-                new TextOf(
-                    new HtResponse(home)
-                ).asString(),
-                Matchers.containsString("HTTP/1.1 200 OK")
-            )
-        );
-    }
-
 }

--- a/src/test/java/org/cactoos/http/HtAutoClosedResponseTest.java
+++ b/src/test/java/org/cactoos/http/HtAutoClosedResponseTest.java
@@ -60,7 +60,7 @@ public final class HtAutoClosedResponseTest {
                 try (InputStream ins = new HtAutoClosedResponse(
                     new HtResponse(
                         new HtWire(() -> socket),
-                        new GetInput(home)
+                        new Get(home)
                     )
                 ).stream()) {
                     int read;

--- a/src/test/java/org/cactoos/http/HtAutoClosedResponseTest.java
+++ b/src/test/java/org/cactoos/http/HtAutoClosedResponseTest.java
@@ -1,0 +1,81 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.http;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.Socket;
+import org.hamcrest.core.IsEqual;
+import org.junit.Test;
+import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.IsTrue;
+import org.takes.http.FtRemote;
+import org.takes.tk.TkText;
+
+/**
+ * Test case for {@link HtAutoClosedResponse}.
+ *
+ * @since 0.1
+ * @checkstyle JavadocMethodCheck (500 lines)
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
+ */
+public final class HtAutoClosedResponseTest {
+    @Test
+    @SuppressWarnings("PMD.AvoidCatchingGenericException")
+    public void closesResponseAndThusSocketWhenEofIsReached() throws Exception {
+        new FtRemote(new TkText("Hey")).exec(
+            home -> {
+                @SuppressWarnings("resource")
+                final Socket socket = new Socket(
+                    home.getHost(),
+                    home.getPort()
+                );
+                try (InputStream ins = new HtAutoClosedResponse(
+                    new HtResponse(
+                        new HtWire(() -> socket),
+                        new GetInput(home)
+                    )
+                ).stream()) {
+                    int read;
+                    do {
+                        read = ins.read();
+                    } while (read != -1);
+                    new Assertion<>(
+                        "must close the response, thus the socket, after EOF",
+                        socket::isClosed,
+                        new IsTrue()
+                    ).affirm();
+                    new Assertion<>(
+                        "must behave as closed",
+                        ins::available,
+                        new IsEqual<>(0)
+                    ).affirm();
+                    // @checkstyle IllegalCatchCheck (1 line)
+                } catch (final Exception ex) {
+                    throw new IOException(ex);
+                }
+            }
+        );
+    }
+}

--- a/src/test/java/org/cactoos/http/HtAutoClosedResponseTest.java
+++ b/src/test/java/org/cactoos/http/HtAutoClosedResponseTest.java
@@ -37,6 +37,12 @@ import org.takes.tk.TkText;
  * Test case for {@link HtAutoClosedResponse}.
  *
  * @since 0.1
+ * @todo #64:30min Introduce abstractions to read from an Input
+ *  without closing the stream as most of the cactoos abstraction
+ *  do. As a starter use them in HtAutoClosedResponseTest, HtWireTest
+ *  and AutoClosedInputStreamTest instead of the ugly while loops or
+ *  meaningless reads. Use them also to actually test the content of
+ *  the inputs.
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */

--- a/src/test/java/org/cactoos/http/HtResponseTest.java
+++ b/src/test/java/org/cactoos/http/HtResponseTest.java
@@ -49,7 +49,7 @@ public final class HtResponseTest {
                 new TextOf(
                     new HtResponse(
                         new HtWire(home),
-                        new GetInput(home)
+                        new Get(home)
                     )
                 ),
                 new TextHasString("HTTP/1.1 200 OK")

--- a/src/test/java/org/cactoos/http/HtTimedWireTest.java
+++ b/src/test/java/org/cactoos/http/HtTimedWireTest.java
@@ -27,8 +27,6 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.util.concurrent.TimeoutException;
 import org.cactoos.io.InputOf;
-import org.cactoos.text.FormattedText;
-import org.cactoos.text.JoinedText;
 import org.cactoos.text.TextOf;
 import org.hamcrest.MatcherAssert;
 import org.junit.After;
@@ -69,13 +67,7 @@ public final class HtTimedWireTest {
                 new TextOf(
                     new HtResponse(
                         new HtTimedWire(new HtWire(home), timeout),
-                        new InputOf(
-                            new JoinedText(
-                                new TextOf("\r\n"),
-                                new TextOf("GET / HTTP/1.1"),
-                                new FormattedText("Host:%s", home.getHost())
-                            )
-                        )
+                        new GetInput(home)
                     )
                 ),
                 new TextHasString("HTTP/1.1 200 ")

--- a/src/test/java/org/cactoos/http/HtTimedWireTest.java
+++ b/src/test/java/org/cactoos/http/HtTimedWireTest.java
@@ -67,7 +67,7 @@ public final class HtTimedWireTest {
                 new TextOf(
                     new HtResponse(
                         new HtTimedWire(new HtWire(home), timeout),
-                        new GetInput(home)
+                        new Get(home)
                     )
                 ),
                 new TextHasString("HTTP/1.1 200 ")

--- a/src/test/java/org/cactoos/http/HtWireTest.java
+++ b/src/test/java/org/cactoos/http/HtWireTest.java
@@ -89,7 +89,7 @@ public final class HtWireTest {
                 new TextOf(
                     new HtResponse(
                         new HtWire(home.getHost(), home.getPort()),
-                        new GetInput(home)
+                        new Get(home)
                     )
                 ),
                 new TextHasString("HTTP/1.1 200")
@@ -113,7 +113,7 @@ public final class HtWireTest {
                     home.getPort()
                 );
                 try (InputStream ins = new HtWire(() -> socket).send(
-                    new GetInput(home)
+                    new Get(home)
                 ).stream()) {
                     new Assertion<>(
                         "must have a response",

--- a/src/test/java/org/cactoos/http/HtWireTest.java
+++ b/src/test/java/org/cactoos/http/HtWireTest.java
@@ -28,12 +28,9 @@ import java.io.InputStream;
 import java.net.Socket;
 import java.net.URI;
 import org.cactoos.BiFunc;
-import org.cactoos.Input;
 import org.cactoos.io.DeadInput;
 import org.cactoos.io.DeadInputStream;
-import org.cactoos.io.InputOf;
 import org.cactoos.text.FormattedText;
-import org.cactoos.text.JoinedText;
 import org.cactoos.text.TextOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
@@ -169,26 +166,5 @@ public final class HtWireTest {
         final Socket socket = Mockito.mock(Socket.class);
         Mockito.when(socket.getInputStream()).thenReturn(new DeadInputStream());
         return socket;
-    }
-
-    /**
-     * An {@link Input} to GET an HTTP URI.
-     */
-    private static final class GetInput extends InputEnvelope {
-        GetInput(final URI url) {
-            super(new InputOf(
-                new JoinedText(
-                    new TextOf("\r\n"),
-                    new FormattedText(
-                        "GET %s HTTP/1.1",
-                        url.getPath()
-                    ),
-                    new FormattedText(
-                        "Host:%s",
-                        url.getHost()
-                    )
-                )
-            ));
-        }
     }
 }

--- a/src/test/java/org/cactoos/http/io/AutoClosedInputStreamTest.java
+++ b/src/test/java/org/cactoos/http/io/AutoClosedInputStreamTest.java
@@ -1,0 +1,89 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.http.io;
+
+import java.io.IOException;
+import java.io.InputStream;
+import org.cactoos.io.DeadInputStream;
+import org.junit.Test;
+import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.IsTrue;
+
+/**
+ * Test case for {@link AutoClosedInputStream}.
+ *
+ * @since 0.1
+ * @checkstyle JavadocMethodCheck (500 lines)
+ * @checkstyle JavadocTypeCheck (500 lines)
+ * @checkstyle JavadocVariableCheck (500 lines)
+ */
+public final class AutoClosedInputStreamTest {
+
+    @Test
+    public void autoClosesTheStream() {
+        new Assertion<Boolean>(
+            "must autoclose the stream",
+            () -> {
+                final CloseableInputStream closeable =
+                    new CloseableInputStream(new DeadInputStream());
+                try (final InputStream ins = new AutoClosedInputStream(
+                    closeable
+                )) {
+                    int read;
+                    do {
+                        read = ins.read();
+                    } while (read != -1);
+                    return closeable.isClosed();
+                }
+            },
+            new IsTrue()
+        ).affirm();
+    }
+
+    private static final class CloseableInputStream extends InputStream {
+
+        private final InputStream origin;
+        private boolean closed;
+
+        CloseableInputStream(final InputStream origin) {
+            super();
+            this.origin = origin;
+        }
+
+        public boolean isClosed() {
+            return this.closed;
+        }
+
+        @Override
+        public int read() throws IOException {
+            return this.origin.read();
+        }
+
+        @Override
+        public void close() throws IOException {
+            this.closed = true;
+            this.origin.close();
+        }
+    }
+}


### PR DESCRIPTION
This is for #64.

- I added many todos to continue the work and also improve things related
- Introduced `HtAutoClosedResponse` that closes the response when EOF is reached
- For now the test mainly passes because of the current implementation of `HtWire` but when #63 is solved, the test should still pass and prove its usefulness.

@llorllale I made some design choices here, please review them carefully too :)