### PR TITLE
(#80) Read from streams in tests without closing

### DIFF
--- a/src/test/java/org/cactoos/http/HtAutoClosedResponseTest.java
+++ b/src/test/java/org/cactoos/http/HtAutoClosedResponseTest.java
@@ -26,9 +26,12 @@ package org.cactoos.http;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.Socket;
+import org.cactoos.http.io.ReadBytes;
+import org.cactoos.text.TextOf;
 import org.junit.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.IsTrue;
+import org.llorllale.cactoos.matchers.TextHasString;
 import org.llorllale.cactoos.matchers.Throws;
 import org.takes.http.FtRemote;
 import org.takes.tk.TkText;
@@ -37,12 +40,6 @@ import org.takes.tk.TkText;
  * Test case for {@link HtAutoClosedResponse}.
  *
  * @since 0.1
- * @todo #64:30min Introduce abstractions to read from an Input
- *  without closing the stream as most of the cactoos abstraction
- *  do. As a starter use them in HtAutoClosedResponseTest, HtWireTest
- *  and AutoClosedInputStreamTest instead of the ugly while loops or
- *  meaningless reads. Use them also to actually test the content of
- *  the inputs.
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
@@ -63,10 +60,11 @@ public final class HtAutoClosedResponseTest {
                         new Get(home)
                     )
                 ).stream()) {
-                    int read;
-                    do {
-                        read = ins.read();
-                    } while (read != -1);
+                    new Assertion<>(
+                        "must have a response",
+                        new TextOf(new ReadBytes(ins)),
+                        new TextHasString("HTTP/1.1 200 OK")
+                    ).affirm();
                     new Assertion<>(
                         "must close the response, thus the socket, after EOF",
                         socket.isClosed(),

--- a/src/test/java/org/cactoos/http/HtWireTest.java
+++ b/src/test/java/org/cactoos/http/HtWireTest.java
@@ -28,12 +28,12 @@ import java.io.InputStream;
 import java.net.Socket;
 import java.net.URI;
 import org.cactoos.BiFunc;
+import org.cactoos.http.io.ReadBytes;
 import org.cactoos.io.DeadInput;
 import org.cactoos.io.DeadInputStream;
 import org.cactoos.text.FormattedText;
 import org.cactoos.text.TextOf;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.core.IsEqual;
 import org.hamcrest.core.IsNot;
 import org.junit.Test;
 import org.llorllale.cactoos.matchers.Assertion;
@@ -111,8 +111,8 @@ public final class HtWireTest {
                 ).stream()) {
                     new Assertion<>(
                         "must have a response",
-                        ins.read(),
-                        new IsNot<>(new IsEqual<>(-1))
+                        new TextOf(new ReadBytes(ins)),
+                        new TextHasString("HTTP/1.1 200 OK")
                     ).affirm();
                     new Assertion<>(
                         "must keep the socket open until response is closed",

--- a/src/test/java/org/cactoos/http/io/CloseableInputStream.java
+++ b/src/test/java/org/cactoos/http/io/CloseableInputStream.java
@@ -23,33 +23,55 @@
  */
 package org.cactoos.http.io;
 
-import org.cactoos.io.DeadInputStream;
-import org.hamcrest.core.IsNot;
-import org.junit.Test;
-import org.llorllale.cactoos.matchers.Assertion;
-import org.llorllale.cactoos.matchers.IsTrue;
+import java.io.IOException;
+import java.io.InputStream;
 
 /**
- * Test case for {@link AutoClosedInputStream}.
+ * Useful {@link InputStream} implementation for tests.
+ *
+ * <p>There is no thread-safety guarantee.
  *
  * @since 0.1
- * @checkstyle JavadocMethodCheck (500 lines)
- * @checkstyle JavadocTypeCheck (500 lines)
- * @checkstyle JavadocVariableCheck (500 lines)
- * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
-public final class AutoClosedInputStreamTest {
+public final class CloseableInputStream extends InputStream {
 
-    @Test
-    public void autoClosesTheStream() throws Exception {
-        final CloseableInputStream closeable = new CloseableInputStream(
-            new DeadInputStream()
-        );
-        new ReadBytes(closeable).asBytes();
-        new Assertion<>(
-            "must not close the stream",
-            closeable.wasClosed(),
-            new IsNot<>(new IsTrue())
-        ).affirm();
+    /**
+     * The wrapped stream.
+     */
+    private final InputStream origin;
+
+    /**
+     * Closed or not.
+     */
+    private boolean closed;
+
+    /**
+     * Ctor.
+     *
+     * @param origin The wrapped stream.
+     */
+    public CloseableInputStream(final InputStream origin) {
+        super();
+        this.origin = origin;
+    }
+
+    /**
+     * Check if stream is closed.
+     *
+     * @return True if the stream was closed.
+     */
+    public boolean wasClosed() {
+        return this.closed;
+    }
+
+    @Override
+    public int read() throws IOException {
+        return this.origin.read();
+    }
+
+    @Override
+    public void close() throws IOException {
+        this.closed = true;
+        this.origin.close();
     }
 }

--- a/src/test/java/org/cactoos/http/io/CloseableInputStreamTest.java
+++ b/src/test/java/org/cactoos/http/io/CloseableInputStreamTest.java
@@ -23,14 +23,18 @@
  */
 package org.cactoos.http.io;
 
+import org.cactoos.Text;
 import org.cactoos.io.DeadInputStream;
+import org.cactoos.io.InputOf;
+import org.cactoos.text.TextOf;
 import org.hamcrest.core.IsNot;
 import org.junit.Test;
 import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.InputHasContent;
 import org.llorllale.cactoos.matchers.IsTrue;
 
 /**
- * Test case for {@link AutoClosedInputStream}.
+ * Test case for {@link CloseableInputStreamTest}.
  *
  * @since 0.1
  * @checkstyle JavadocMethodCheck (500 lines)
@@ -38,18 +42,35 @@ import org.llorllale.cactoos.matchers.IsTrue;
  * @checkstyle JavadocVariableCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
-public final class AutoClosedInputStreamTest {
-
+public final class CloseableInputStreamTest {
     @Test
-    public void autoClosesTheStream() throws Exception {
+    public void doesNotCloseTheStream() throws Exception {
         final CloseableInputStream closeable = new CloseableInputStream(
             new DeadInputStream()
         );
-        new ReadBytes(closeable).asBytes();
         new Assertion<>(
-            "must not close the stream",
+            "must not be marked as closed before close is called",
             closeable.wasClosed(),
             new IsNot<>(new IsTrue())
+        ).affirm();
+        closeable.close();
+        new Assertion<>(
+            "must be marked as closed after close is called",
+            closeable.wasClosed(),
+            new IsTrue()
+        ).affirm();
+    }
+
+    @Test
+    public void wrapsAndInputStream() throws Exception {
+        final Text text = new TextOf("test");
+        final CloseableInputStream closeable = new CloseableInputStream(
+            new InputOf(text).stream()
+        );
+        new Assertion<>(
+            "must allow to read the stream",
+            new InputOf(closeable),
+            new InputHasContent(text)
         ).affirm();
     }
 }

--- a/src/test/java/org/cactoos/http/io/ReadBytes.java
+++ b/src/test/java/org/cactoos/http/io/ReadBytes.java
@@ -1,0 +1,81 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.http.io;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import org.cactoos.Bytes;
+import org.cactoos.Input;
+import org.cactoos.Scalar;
+import org.cactoos.scalar.StickyScalar;
+
+/**
+ * Reads available data from {@link Input} as {@link Bytes} only once
+ * and without closing it.
+ *
+ * <p>There is no thread-safety guarantee.
+ *
+ * @since 0.1
+ */
+public final class ReadBytes implements Bytes {
+
+    /**
+     * Bytes from the input stream.
+     */
+    private final Scalar<byte[]> scalar;
+
+    /**
+     * Ctor.
+     *
+     * @param input The input
+     */
+    public ReadBytes(final InputStream input) {
+        // @checkstyle MagicNumber (1 line)
+        this(input, 16 << 10);
+    }
+
+    /**
+     * Ctor.
+     *
+     * @param input The input
+     * @param max Max length of the buffer for reading
+     */
+    public ReadBytes(final InputStream input, final int max) {
+        this.scalar = new StickyScalar<>(
+            () -> {
+                final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                final byte[] buf = new byte[max];
+                while (input.read(buf) >= 0) {
+                    baos.write(buf);
+                }
+                return baos.toByteArray();
+            }
+        );
+    }
+
+    @Override
+    public byte[] asBytes() throws Exception {
+        return this.scalar.value();
+    }
+}

--- a/src/test/java/org/cactoos/http/io/ReadBytesTest.java
+++ b/src/test/java/org/cactoos/http/io/ReadBytesTest.java
@@ -24,13 +24,12 @@
 package org.cactoos.http.io;
 
 import org.cactoos.io.DeadInputStream;
-import org.hamcrest.core.IsNot;
 import org.junit.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.IsTrue;
 
 /**
- * Test case for {@link AutoClosedInputStream}.
+ * Test case for {@link ReadBytesTest}.
  *
  * @since 0.1
  * @checkstyle JavadocMethodCheck (500 lines)
@@ -38,18 +37,17 @@ import org.llorllale.cactoos.matchers.IsTrue;
  * @checkstyle JavadocVariableCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
-public final class AutoClosedInputStreamTest {
-
+public final class ReadBytesTest {
     @Test
-    public void autoClosesTheStream() throws Exception {
+    public void doesNotCloseTheStream() throws Exception {
         final CloseableInputStream closeable = new CloseableInputStream(
             new DeadInputStream()
         );
-        new ReadBytes(closeable).asBytes();
+        new ReadBytes(new AutoClosedInputStream(closeable)).asBytes();
         new Assertion<>(
-            "must not close the stream",
+            "must autoclose the stream",
             closeable.wasClosed(),
-            new IsNot<>(new IsTrue())
+            new IsTrue()
         ).affirm();
     }
 }


### PR DESCRIPTION
This is for #80:
- introduced an abstraction to read from a stream without closing it
- use it to actually test that what is read is correct in the various tests